### PR TITLE
Add support for PIN authentication

### DIFF
--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -25,9 +25,10 @@ MTU_SIZE = 20
 
 
 class Mower:
-    def __init__(self, channel_id: int, address):
+    def __init__(self, channel_id: int, address, pin=None):
         self.channel_id = channel_id
         self.address = address
+        self.pin = pin
 
         self.request = MowerRequest(channel_id)
         self.response = MowerResponse(channel_id)
@@ -199,6 +200,14 @@ class Mower:
             return False
 
         ### TODO: Check response
+
+        if self.pin is not None:
+            request = self.request.generate_request_pin(self.pin)
+            response = await self._request_response(request)
+            if response == None:
+                return False
+
+            ### TODO: Check response
 
         return True
 
@@ -434,9 +443,16 @@ if __name__ == "__main__":
         help="the Bluetooth address of the Automower device to connect to",
     )
 
+    parser.add_argument(
+        "--pin",
+        metavar="<code>",
+        type=int,
+        default=None,
+        help="Send PIN to authenticate. This feature is experimental and might not work.",
+    )
     args = parser.parse_args()
 
-    mower = Mower(1197489078, args.address)
+    mower = Mower(1197489078, args.address, args.pin)
 
     log_level = logging.INFO
     logging.basicConfig(


### PR DESCRIPTION
Based on discussions and logs in #3 I've added the option to include PIN authentication in `mower.py`. 

I guess this should mimic the behavior of [Automower Direct](https://www.husqvarna.com/ie/support/husqvarna-self-service/how-to-add-an-automower-robotic-lawn-mower-to-automower-connect-ka-01272/) which should allow connections without the mower needed to be paired upfront:

> All our Automower® robotic lawn mowers* can be connected using a temporary connection. The connection is established using Bluetooth and the Automower® Direct login option. This option requires the Automower® Connect app, but it does not require being logged in to an account. You have to enter the mower PIN code and establish a new connection every time you want to access or control the mower using your mobile device.

For security reasons, implementations of this library should primarily be using the PIN-less pairing method as no credentials can be stolen. 