### PR TITLE
fallback to "untested" device

### DIFF
--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -389,7 +389,11 @@ async def main(mower):
 
     await mower.connect(device)
 
-    model = await mower.get_model()
+    try: 
+        model = await mower.get_model()
+    except KeyError:
+        model = "Untested"
+
     print("Connected to: " + model)
 
     charging = await mower.is_charging()


### PR DESCRIPTION
ref https://github.com/alistair23/AutoMower-BLE/issues/3#issuecomment-2076439571, rationale being that we acknowledge this device is infact an Husqvarna (since it was detected) variant however it's untested. With this change the user will be able to test the commands and give feedback if not working, which would trigger further investigation into properly handling the device