### PR TITLE
Add Sileno City 250 (Gardena)

### DIFF
--- a/automower_ble/models.py
+++ b/automower_ble/models.py
@@ -39,6 +39,7 @@ MowerModels = dict(
         ((40, 2), "450XHEPOS"),
         ((24, 2), "Ceora544EPOS"),
         ((24, 1), "Ceora546EPOS"),
+        ((14, 1), "SilenoCity250"),
         ((29, 2), "Minimo"),
         ((29, 3), "Minimo-500"),
         ((31, 1), "320Nera"),


### PR DESCRIPTION
Adding the Sileno City 250 based on analysis of my own lawn mower.

Reviewing the decompiled Gardena app, I noticed the following types and variants:

> - MowerModel.Type14.Variant1.INSTANCE
> - MowerModel.Type14.Variant2.INSTANCE
> - MowerModel.Type14.Variant3.INSTANCE
> - MowerModel.Type14.Variant4.INSTANCE
> - MowerModel.Type14.Variant5.INSTANCE
> - MowerModel.Type14.Variant6.INSTANCE
> - SmartMowerModel.Type14.Variant7.INSTANCE
> - SmartMowerModel.Type14.Variant8.INSTANCE
> - MowerModel.Type14.Variant9.INSTANCE
> - MowerModel.Type14.Variant10.INSTANCE
> - MowerModel.Type14.Variant11.INSTANCE
> - SmartMowerModel.Type14.Variant12.INSTANCE
> - MowerModel.Type14.Variant13.INSTANCE
> - SmartMowerModel.Type14.Variant14.INSTANCE
> - SmartMowerModel.Type14.Variant15.INSTANCE
> - SmartMowerModel.Type14.Variant16.INSTANCE
> - SmartMowerModel.Type14.Variant17.INSTANCE
> - MowerModel.Type14.Variant18.INSTANCE

> - MowerModel.Type18.Variant1.INSTANCE
> - MowerModel.Type18.Variant2.INSTANCE
> - MowerModel.Type18.Variant3.INSTANCE
> - SmartMowerModel.Type18.Variant4.INSTANCE
> - SmartMowerModel.Type18.Variant5.INSTANCE
> - SmartMowerModel.Type18.Variant6.INSTANCE
> - MowerModel.Type18.Variant7.INSTANCE
> - MowerModel.Type18.Variant8.INSTANCE
> - SmartMowerModel.Type18.Variant9.INSTANCE
> - SmartMowerModel.Type18.Variant10.INSTANCE
> - SmartMowerModel.Type18.Variant11.INSTANCE
> - MowerModel.Type18.Variant12.INSTANCE
> - MowerModel.Type18.Variant13.INSTANCE
> - SmartMowerModel.Type18.Variant14.INSTANCE
> - SmartMowerModel.Type18.Variant15.INSTANCE
> - MowerModel.Type18.Variant16.INSTANCE
> - SmartMowerModel.Type18.Variant17.INSTANCE

> - MowerModel.Type29.Variant1.INSTANCE
> - MowerModel.Type29.Variant2.INSTANCE
> - MowerModel.Type29.Variant3.INSTANCE
> - MowerModel.Type29.Variant4.INSTANCE
> - MowerModel.Type29.Variant5.INSTANCE
> - MowerModel.Type29.Variant6.INSTANCE
> - MowerModel.Type29.Variant7.INSTANCE
> - MowerModel.Type29.Variant8.INSTANCE
> - MowerModel.Type29.Variant9.INSTANCE
> - MowerModel.Type29.Variant10.INSTANCE

I suspect Type14 is Sileno City and Type 29 is Minimo. The only one missing then is Sileno Life, which probably is Type 18.

Would it be good to all all these types and variants already to the list of models with maybe a name like "Unknown"?
Would it be good to make a manufacturer to every model (like husqvarna, gardena, flymo, mccullogh)? That would help setting the right manufacturer and model in HA (https://developers.home-assistant.io/docs/device_registry_index/)

