### PR TITLE
Update to include json files in build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ classifiers = [
   "Environment :: Console",
   "Programming Language :: Python :: 3",
 ]
+
+[tool.setuptools.package-data]
+automower_ble = ["*.json"]


### PR DESCRIPTION
I'm trying to get the current state of this repo compatible with the HA core pull but `protocol.json` was not found so I found out it was not treated as a data file in the build system. This PR fixes this and can be checked by running `python -m build` before and after this PR.

