### PR TITLE
Protocol additions

### DIFF
--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -18,6 +18,7 @@ from .protocol import (
     MowerActivity,
     ModeOfOperation,
     TaskInformation,
+    OverrideAction,
 )
 from .models import MowerModels
 from .error_codes import ErrorCodes
@@ -215,7 +216,10 @@ async def main(mower: Mower):
     print("\t" + ErrorCodes(last_message["code"]).name)
 
     mower_name = await mower.get_parameter("GetUserMowerNameAsAsciiString")
-    print("Mower name:" + mower_name)
+    print("Mower name: " + mower_name)
+
+    override = await mower.get_parameter("GetOverride")
+    print("Mower override: " + str(OverrideAction(override['action'])))
 
     # print("Running for 3 hours")
     # await mower.mower_override()

--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -213,6 +213,10 @@ async def main(mower: Mower):
         )
     )
     print("\t" + ErrorCodes(last_message["code"]).name)
+
+    mower_name = await mower.get_parameter("GetUserMowerNameAsAsciiString")
+    print("Mower name:" + mower_name)
+
     # print("Running for 3 hours")
     # await mower.mower_override()
 

--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -84,7 +84,7 @@
     "getModeOfOperation": {
         "major": 4586,
         "minor": 1,
-        "responseType":"uint8",
+        "responseType": "uint8",
         "description": "Get mode of operation"
     },
     "mowerState": {
@@ -144,7 +144,7 @@
         "responseType": "no_response",
         "description": "Main override request"
     },
-    "requestTrigger":{
+    "requestTrigger": {
         "major": 4586,
         "minor": 4,
         "responseType": "no_response",
@@ -153,7 +153,7 @@
     "keepalive": {
         "major": 4674,
         "minor": 2,
-        "responseType":"no_response",
+        "responseType": "no_response",
         "description": "Sending a keep alive to the mower"
     },
     "getStartupSequenceRequiredRequest": {
@@ -168,22 +168,22 @@
         "responseType": "bool",
         "description": "Check if the operator is logged in or not"
     },
-    "getRestrictionReason":{
+    "getRestrictionReason": {
         "major": 4658,
         "minor": 0,
-        "responseType":"uint8",
+        "responseType": "uint8",
         "description": "Get the type of reason of restriction"
     },
-    "getNumberOfTasks" : {
+    "getNumberOfTasks": {
         "major": 4690,
         "minor": 4,
-        "responseType":"uint32",
+        "responseType": "uint32",
         "description": "Get the number of tasks"
     },
     "getTask": {
         "major": 4690,
         "minor": 5,
-        "requestType":{
+        "requestType": {
             "task": "uint8"
         },
         "responseType": {
@@ -196,8 +196,14 @@
             "on_friday": "bool",
             "on_saturday": "bool",
             "on_sunday": "bool",
-            "unknown": "uint16"            
+            "unknown": "uint16"
         },
         "description": "Get a specified task"
+    },
+    "GetUserMowerNameAsAsciiString": {
+        "major": 4698,
+        "minor": 5,
+        "description": "Get the user defined mower name",
+        "responseType": "ascii"
     }
 }

--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -245,5 +245,20 @@
         "minor": 6,
         "description": "Clear the override status of the mower",
         "responseType": "no_response"
+    },
+    "GetReversingDistance": {
+        "major": 4716,
+        "minor": 0,
+        "description": "Get reversing distance from charging station in mm",
+        "responseType": "uint16"
+    },
+    "SetReversingDistance": {
+        "major": 4716,
+        "minor": 1,
+        "description": "Set the reversing distance from charging station in mm. In the app, this is controlled in whole cm from 15cm to 300cm",
+        "requestType": {
+            "distance": "uint16"
+        },
+        "responseType": "no_response"
     }
 }

--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -205,5 +205,45 @@
         "minor": 5,
         "description": "Get the user defined mower name",
         "responseType": "ascii"
+    },
+    "GetOverride": {
+        "major": 4658,
+        "minor": 2,
+        "description": "Get the override status of the mower",
+        "responseType": {
+            "action": "uint8",
+            "startTime": "tUnixTime",
+            "duration": "uint32"
+        }
+    },
+    "SetOverrideMow": {
+        "major": 4658,
+        "minor": 3,
+        "description": "Enable override mow for the specified duration",
+        "requestType": {
+            "duration": "uint32"
+        },
+        "responseType": "no_response"
+    },
+    "SetOverridePark": {
+        "major": 4658,
+        "minor": 4,
+        "description": "Park the mower for the specified duration",
+        "requestType": {
+            "duration": "uint32"
+        },
+        "responseType": "no_response"
+    },
+    "SetOverrideParkUntilNextStart": {
+        "major": 4658,
+        "minor": 5,
+        "description": "Park until next scheduled start",
+        "responseType": "no_response"
+    },
+    "ClearOverride": {
+        "major": 4658,
+        "minor": 6,
+        "description": "Clear the override status of the mower",
+        "responseType": "no_response"
     }
 }

--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -48,6 +48,10 @@ class MowerActivity(Enum):
     PARKED = 5
     STOPPED_IN_GARDEN = 6  # Mower has stopped. Needs manual action to resume
 
+class OverrideAction(Enum):
+    NONE = 0
+    FORCEDPARK = 1  
+    FORCEDMOW = 2
 
 class TaskInformation(object):
     def __init__(

--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -163,7 +163,7 @@ class Command:
 
         return self.request_data
 
-    def parse_response(self, response_data: bytearray) -> int | None:
+    def parse_response(self, response_data: bytearray) -> int | str | dict | None:
         response_length = response_data[17]
         data = response_data[19 : 19 + response_length]
         response = dict()
@@ -184,6 +184,15 @@ class Command:
             elif (dtype == "uint8") or (dtype == "bool"):
                 response[name] = data[dpos]
                 dpos += 1
+            elif dtype == "ascii":
+                if len(self.response_data_type) != 1:
+                    raise ValueError(
+                        "ASCII response type can currently only be used when there is only one response type"
+                    )
+                response[name] = data.decode("ascii").rstrip(
+                    "\x00"
+                )  # Remove trailing null bytes
+                dpos += len(data)
             else:
                 raise ValueError("Unknown data type: " + dtype)
         if dpos != len(data):


### PR DESCRIPTION
Adding some stuff to the protocol:

1. Possibility to extract Mower name and get ASCII responses
2. Override protocol 
3. Reversing distance (I'm thinking about changing this randomly every week to reduce the stress on that spot where the mower always turn)

The override protocol requested for #36 should now probably be used for the `mower_[override,pause,resume,park]`. 

As some of the changes introduced duplicates (e.g. `4658, 3`) I will keep this as a draft until that is fixed. Let me know if there is any feedback.