### PR TITLE
Update enum types to use IntEnum

### DIFF
--- a/automower_ble/error_codes.py
+++ b/automower_ble/error_codes.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import IntEnum
 
 
-class ErrorCodes(Enum):
+class ErrorCodes(IntEnum):
     UNEXPECTED_ERROR = 0
     OUTSIDE_WORKING_AREA = 1
     NO_LOOP_SIGNAL = 2

--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -186,10 +186,12 @@ async def main(mower: Mower):
     print("Battery is: " + str(battery_level) + "%")
 
     state = await mower.mower_state()
-    print("Mower state: " + str(state))
+    if state is not None:
+        print("Mower state: " + state.name)
 
     activity = await mower.mower_activity()
-    print("Mower activity: " + str(activity))
+    if activity is not None:
+        print("Mower activity: " + activity.name)
 
     next_start_time = await mower.mower_next_start_time()
     if next_start_time:
@@ -205,7 +207,7 @@ async def main(mower: Mower):
     print("Serial number: " + str(serial_number))
 
     mower_name = await mower.get_parameter("GetUserMowerNameAsAsciiString")
-    print("Mower name:" + mower_name)
+    print("Mower name: " + mower_name)
 
     # print("Running for 3 hours")
     # await mower.mower_override()

--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -1,6 +1,6 @@
 import binascii
 from .helpers import crc
-from enum import Enum
+from enum import IntEnum
 import asyncio
 import logging
 import json
@@ -11,7 +11,7 @@ from bleak.backends.characteristic import BleakGATTCharacteristic
 logger = logging.getLogger(__name__)
 
 
-class ModeOfOperation(Enum):
+class ModeOfOperation(IntEnum):
     # ProtocolTypes$IMowerAppMowerMode, used in modeOfOperation: 4586, 1
     # Comments from: https://developer.husqvarnagroup.cloud/apis/Automower+Connect+API?tab=status%20description%20and%20error%20codes#user-content-mode
     AUTO = 0
@@ -21,7 +21,7 @@ class ModeOfOperation(Enum):
     POI = 4
 
 
-class MowerState(Enum):
+class MowerState(IntEnum):
     # ProtocolTypes$IMowerAppState, used in mowerState: 4586, 2
     # Comments from: https://developer.husqvarnagroup.cloud/apis/Automower+Connect+API?tab=status%20description%20and%20error%20codes#user-content-state
     OFF = 0  # Mower is turned off.
@@ -37,7 +37,7 @@ class MowerState(Enum):
     ERROR = 8  # An error has occurred. Check errorCode. Mower requires manual action.
 
 
-class MowerActivity(Enum):
+class MowerActivity(IntEnum):
     # ProtocolTypes$IMowerAppActivity, used in mowerActivity: 4586, 3
     # Comments from: https://developer.husqvarnagroup.cloud/apis/Automower+Connect+API?tab=status%20description%20and%20error%20codes#user-content-activity
     NONE = 0


### PR DESCRIPTION
As highlighted in #56 , the `protocol.py` uses the `to_bytes` method and it would be better to use `IntEnum`'s as this allows for a simpler and better looking syntax. 

With `IntEnum`'s we can pass `mode=ModeOfOperation.AUTO` instead of `mode=ModeOfOperation.AUTO.value`