### PR TITLE
Improved notation for the communication protocol

### DIFF
--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -1,50 +1,50 @@
 {
-    "nextStartTime": {
+    "GetNextStartTime": {
         "major": 4658,
         "minor": 1,
         "responseType": "tUnixTime",
         "description": "Next start time, if available."
     },
-    "batteryLevel": {
+    "GetBatteryLevel": {
         "major": 4106,
         "minor": 20,
         "responseType": "uint8",
         "description": "Battery level in percent."
     },
-    "isCharging": {
+    "IsCharging": {
         "major": 4106,
         "minor": 21,
         "responseType": "bool",
         "description": "Indicates if the mower is charging."
     },
-    "deviceType": {
+    "GetModel": {
         "major": 4698,
         "minor": 9,
         "responseType": {
             "deviceType": "uint8",
-            "deviceSubType": "uint8"
+            "deviceVariant": "uint8"
         },
         "description": "Device type tuple."
     },
-    "numberOfMessages": {
+    "GetNumberOfMessages": {
         "major": 4730,
         "minor": 0,
         "responseType": "uint32",
         "description": "Number of messages in the message log."
     },
-    "getMessage": {
+    "GetMessage": {
         "major": 4730,
         "minor": 1,
         "requestType": {
             "messageId": "uint32"
         },
         "responseType": {
-            "messageTime": "tUnixTime",
+            "time": "tUnixTime",
             "code": "uint32",
             "severity": "uint8"
         }
     },
-    "getStatuses": {
+    "GetAllStatistics": {
         "major": 4726,
         "minor": 0,
         "responseType": {
@@ -57,145 +57,149 @@
             "cuttingBladeUsageTime": "uint32"
         }
     },
-    "pin": {
+    "EnterOperatorPin": {
         "major": 4664,
         "minor": 4,
         "requestType": {
             "code": "uint16"
         },
-        "responseType": "no_response",
         "description": "PIN code for the mower."
     },
-    "remainingChargeTime": {
+    "GetRemainingChargingTime": {
         "major": 4106,
         "minor": 22,
         "responseType": "uint32",
         "description": "Remaining charge time."
     },
-    "setModeOfOperation": {
+    "SetMode": {
         "major": 4586,
         "minor": 0,
         "requestType": {
             "mode": "uint8"
         },
-        "responseType": "no_response",
         "description": "Set mode of operation."
     },
-    "getModeOfOperation": {
+    "GetMode": {
         "major": 4586,
         "minor": 1,
         "responseType": "uint8",
         "description": "Get mode of operation"
     },
-    "mowerState": {
+    "GetState": {
         "major": 4586,
         "minor": 2,
         "responseType": "uint8",
         "description": "Mower state."
     },
-    "mowerActivity": {
+    "GetActivity": {
         "major": 4586,
         "minor": 3,
         "responseType": "uint8",
         "description": "Mower activity."
     },
-    "resume": {
+    "StartTrigger": {
         "major": 4586,
         "minor": 4,
-        "responseType": "no_response",
-        "description": "Resume mower."
+        "description": "Unknown what this is. Resume?"
     },
-    "pause": {
+    "Pause": {
         "major": 4586,
         "minor": 5,
-        "responseType": "no_response",
         "description": "Pause mower."
     },
-    "errorCode": {
+    "GetError": {
         "major": 4586,
         "minor": 6,
         "responseType": "uint32",
         "description": "Error code."
     },
-    "overrideDuration": {
+    "SetOverrideMow": {
         "major": 4658,
         "minor": 3,
         "requestType": {
             "duration": "uint32"
         },
-        "responseType": "no_response",
-        "description": "Override duration for the specified duration in seconds."
+        "description": "Override mow for a specified duration in seconds."
     },
-    "park": {
+    "SetOverridePark": {
+        "major": 4658,
+        "minor": 4,
+        "requestType": {
+            "duration": "uint32"
+        },
+        "description": "Park mower for a specified duration in seconds."
+    },
+    "SetOverrideParkUntilNextStart": {
         "major": 4658,
         "minor": 5,
-        "responseType": "no_response",
-        "description": "Park mower."
+        "description": "Park mower until next scheduled start."
     },
-    "serialNumber": {
+    "ClearOverride": {
+        "major": 4658,
+        "minor": 6,
+        "description": "Clear the current override status."
+    },
+    "GetSerialNumber": {
         "major": 4698,
         "minor": 10,
         "responseType": "uint32",
         "description": "Serial number of the mower."
     },
-    "override": {
+    "GetOverride": {
         "major": 4658,
         "minor": 2,
-        "responseType": "no_response",
-        "description": "Main override request"
+        "responseType": {
+            "action": "uint8",
+            "startTime": "tUnixTime",
+            "duration": "uint32"
+        },
+        "description": "Override status."
     },
-    "requestTrigger": {
-        "major": 4586,
-        "minor": 4,
-        "responseType": "no_response",
-        "description": "Requesting trigger"
-    },
-    "keepalive": {
+    "KeepAlive": {
         "major": 4674,
         "minor": 2,
-        "responseType": "no_response",
         "description": "Sending a keep alive to the mower"
     },
-    "getStartupSequenceRequiredRequest": {
+    "GetStartupSequenceRequired": {
         "major": 4698,
         "minor": 2,
         "responseType": "bool",
         "description": "Request mower if startup sequence is required or not"
     },
-    "isOperatorLoggedIn": {
+    "IsOperatorLoggedIn": {
         "major": 4664,
         "minor": 3,
         "responseType": "bool",
         "description": "Check if the operator is logged in or not"
     },
-    "getRestrictionReason": {
+    "GetRestrictionReason": {
         "major": 4658,
         "minor": 0,
         "responseType": "uint8",
         "description": "Get the type of reason of restriction"
     },
-    "getNumberOfTasks": {
+    "GetNumberOfTasks": {
         "major": 4690,
         "minor": 4,
         "responseType": "uint32",
         "description": "Get the number of tasks"
     },
-    "getTask": {
+    "GetTask": {
         "major": 4690,
         "minor": 5,
         "requestType": {
-            "task": "uint8"
+            "taskId": "uint32"
         },
         "responseType": {
-            "next_start_time": "uint32",
-            "duration_in_seconds": "uint32",
-            "on_monday": "bool",
-            "on_tuesday": "bool",
-            "on_wednesday": "bool",
-            "on_thursday": "bool",
-            "on_friday": "bool",
-            "on_saturday": "bool",
-            "on_sunday": "bool",
+            "start": "uint32",
+            "duration": "uint32",
+            "useOnMonday": "bool",
+            "useOnTuesday": "bool",
+            "useOnWednesday": "bool",
+            "useOnThursday": "bool",
+            "useOnFriday": "bool",
+            "useOnSaturday": "bool",
+            "useOnSunday": "bool",
             "unknown": "uint16"
         },
         "description": "Get a specified task"

--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -49,6 +49,12 @@ class MowerActivity(IntEnum):
     STOPPED_IN_GARDEN = 6  # Mower has stopped. Needs manual action to resume
 
 
+class OverrideAction(IntEnum):
+    NONE = 0
+    FORCEDPARK = 1
+    FORCEDMOW = 2
+
+
 class TaskInformation(object):
     def __init__(
         self,
@@ -84,6 +90,9 @@ class Command:
             self.request_data_type = parameter["requestType"]
         else:
             self.request_data_type = None
+
+        if "responseType" not in parameter:
+            parameter["responseType"] = "no_response"
 
         if not isinstance(parameter["responseType"], dict):  # Always wrap in list
             self.response_data_type = {"response": parameter["responseType"]}
@@ -433,7 +442,7 @@ class BLEClient:
         ### TODO: Check response
 
         if self.pin is not None:
-            command = Command(self.channel_id, self.protocol["pin"])
+            command = Command(self.channel_id, self.protocol["EnterOperatorPin"])
             request = command.generate_request(code=self.pin)
             response = await self._request_response(request)
             if response is None:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -33,7 +33,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_request_device_type(self):
-        command = Command(1739453030, parameter=self.protocol["deviceType"])
+        command = Command(1739453030, parameter=self.protocol["GetModel"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -41,7 +41,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_request_pin(self):
-        command = Command(1739453030, parameter=self.protocol["pin"])
+        command = Command(1739453030, parameter=self.protocol["EnterOperatorPin"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request(code=7201)),
@@ -49,7 +49,9 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_request_remaining_charge_time(self):
-        command = Command(1197489075, parameter=self.protocol["remainingChargeTime"])
+        command = Command(
+            1197489075, parameter=self.protocol["GetRemainingChargingTime"]
+        )
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -57,7 +59,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_request_is_charging(self):
-        command = Command(1197489075, parameter=self.protocol["isCharging"])
+        command = Command(1197489075, parameter=self.protocol["IsCharging"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -65,7 +67,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_request_battery_level(self):
-        command = Command(1197489075, parameter=self.protocol["batteryLevel"])
+        command = Command(1197489075, parameter=self.protocol["GetBatteryLevel"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -73,7 +75,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_request_set_mode_of_operation(self):
-        command = Command(0x5798CA1A, parameter=self.protocol["setModeOfOperation"])
+        command = Command(0x5798CA1A, parameter=self.protocol["SetMode"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request(mode=ModeOfOperation.AUTO.value)),
@@ -81,7 +83,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_request_get_mode_of_operation(self):
-        command = Command(0x5798CA1A, parameter=self.protocol["getModeOfOperation"])
+        command = Command(0x5798CA1A, parameter=self.protocol["GetMode"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -89,7 +91,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_request_override_duration(self):
-        command = Command(0x5798CA1A, parameter=self.protocol["overrideDuration"])
+        command = Command(0x5798CA1A, parameter=self.protocol["SetOverrideMow"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request(duration=3 * 3600)),
@@ -97,15 +99,15 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_get_task_request(self):
-        command = Command(0x13A51453, parameter=self.protocol["getTask"])
+        command = Command(0x13A51453, parameter=self.protocol["GetTask"])
 
         self.assertEqual(
-            binascii.hexlify(command.generate_request(task=0)),
-            b"02fd11005314a513015400af52120500010000ca03",
+            binascii.hexlify(command.generate_request(taskId=0)),
+            b"02fd14005314a513019d00af52120500040000000000d203",
         )
 
     def test_generate_get_number_of_tasks_request(self):
-        command = Command(0x13A51453, parameter=self.protocol["getNumberOfTasks"])
+        command = Command(0x13A51453, parameter=self.protocol["GetNumberOfTasks"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -113,7 +115,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_get_restriction_reason(self):
-        command = Command(0x13A51453, parameter=self.protocol["getRestrictionReason"])
+        command = Command(0x13A51453, parameter=self.protocol["GetRestrictionReason"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -121,7 +123,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_get_serial_number(self):
-        command = Command(0x13A51453, parameter=self.protocol["serialNumber"])
+        command = Command(0x13A51453, parameter=self.protocol["GetSerialNumber"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -129,7 +131,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_is_operator_loggedin_request(self):
-        command = Command(0x13A51453, parameter=self.protocol["isOperatorLoggedIn"])
+        command = Command(0x13A51453, parameter=self.protocol["IsOperatorLoggedIn"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -138,7 +140,7 @@ class TestRequestMethods(unittest.TestCase):
 
     def test_generate_getStartupSequenceRequiredRequest(self):
         command = Command(
-            0x13A51453, parameter=self.protocol["getStartupSequenceRequiredRequest"]
+            0x13A51453, parameter=self.protocol["GetStartupSequenceRequired"]
         )
 
         self.assertEqual(
@@ -147,7 +149,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_keepalive_request(self):
-        command = Command(0x13A51453, parameter=self.protocol["keepalive"])
+        command = Command(0x13A51453, parameter=self.protocol["KeepAlive"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -155,7 +157,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_request_trigger_request(self):
-        command = Command(0x13A51453, parameter=self.protocol["requestTrigger"])
+        command = Command(0x13A51453, parameter=self.protocol["StartTrigger"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),
@@ -163,7 +165,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_generate_request_override(self):
-        command = Command(0x13A51453, parameter=self.protocol["override"])
+        command = Command(0x13A51453, parameter=self.protocol["GetOverride"])
 
         self.assertEqual(
             binascii.hexlify(command.generate_request()),

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -11,13 +11,13 @@ class TestRequestMethods(unittest.TestCase):
             self.protocol = json.load(f)  # Load the parameters to have them available
 
     def test_decode_response_device_type(self):
-        command = Command(1197489078, parameter=self.protocol["deviceType"])
+        command = Command(1197489078, parameter=self.protocol["GetModel"])
 
         response = command.parse_response(
             bytearray.fromhex("02fd1300b63b604701e601af5a1209000002001701c803")
         )
         self.assertEqual(
-            MowerModels[(response["deviceType"], response["deviceSubType"])].model,
+            MowerModels[(response["deviceType"], response["deviceVariant"])].model,
             "Automower 305",
         )
 
@@ -25,12 +25,12 @@ class TestRequestMethods(unittest.TestCase):
             bytearray.fromhex("02fd130038e38f0b01dc01af5a1209000002000c005903")
         )
         self.assertEqual(
-            MowerModels[(response["deviceType"], response["deviceSubType"])].model,
+            MowerModels[(response["deviceType"], response["deviceVariant"])].model,
             "Automower 315",
         )
 
     def test_decode_response_is_charging(self):
-        command = Command(1197489078, self.protocol["isCharging"])
+        command = Command(1197489078, self.protocol["IsCharging"])
 
         self.assertEqual(
             command.parse_response(
@@ -46,7 +46,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_decode_response_mower_state(self):
-        command = Command(1197489078, self.protocol["mowerState"])
+        command = Command(1197489078, self.protocol["GetState"])
 
         self.assertNotIn(
             command.parse_response(
@@ -55,7 +55,7 @@ class TestRequestMethods(unittest.TestCase):
             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14],  # 11=unknown
         )
 
-        command = Command(876143061, self.protocol["mowerState"])
+        command = Command(876143061, self.protocol["GetState"])
         self.assertEqual(
             command.parse_response(
                 bytearray.fromhex("02fd1200d5e13834012301afea110200000100033a03")
@@ -64,7 +64,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_decode_response_mower_activity(self):
-        response = Command(1197489078, self.protocol["mowerActivity"])
+        response = Command(1197489078, self.protocol["GetActivity"])
 
         self.assertEqual(
             response.parse_response(
@@ -74,7 +74,7 @@ class TestRequestMethods(unittest.TestCase):
         )
 
     def test_decode_get_task_response(self):
-        response = Command(1197489078, self.protocol["getTask"])
+        response = Command(1197489078, self.protocol["GetTask"])
         decoded = response.parse_response(
             bytearray.fromhex(
                 "02fd240025be246a010701af5212050000130000e1000038310000010001010001013003"
@@ -82,23 +82,23 @@ class TestRequestMethods(unittest.TestCase):
         )
 
         self.assertEqual(
-            decoded["next_start_time"],
+            decoded["start"],
             57600,
         )
         self.assertEqual(
-            decoded["duration_in_seconds"],
-            12600,  # 2 = goingOut
+            decoded["duration"],
+            12600,
         )
-        self.assertEqual(decoded["on_monday"], 1)
-        self.assertEqual(decoded["on_tuesday"], 0)
-        self.assertEqual(decoded["on_wednesday"], 1)
-        self.assertEqual(decoded["on_thursday"], 1)
-        self.assertEqual(decoded["on_friday"], 0)
-        self.assertEqual(decoded["on_saturday"], 1)
-        self.assertEqual(decoded["on_sunday"], 1)
+        self.assertEqual(decoded["useOnMonday"], 1)
+        self.assertEqual(decoded["useOnTuesday"], 0)
+        self.assertEqual(decoded["useOnWednesday"], 1)
+        self.assertEqual(decoded["useOnThursday"], 1)
+        self.assertEqual(decoded["useOnFriday"], 0)
+        self.assertEqual(decoded["useOnSaturday"], 1)
+        self.assertEqual(decoded["useOnSunday"], 1)
 
     def test_decode_get_number_of_tasks_response(self):
-        response = Command(0x13A51453, self.protocol["getNumberOfTasks"])
+        response = Command(0x13A51453, self.protocol["GetNumberOfTasks"])
         self.assertEqual(
             response.parse_response(
                 bytearray.fromhex("02fd150025be246a012e01af52120400000400010000004f03")


### PR DESCRIPTION
The PR improves the notation of the name and parameters of the commands sent to the mower. I've been looking at the Android APK of McCulloch ROB_2.2.2 using jaxd, saved out the project and looked at the files under `app/src/main/java/com/gardena/libraries/bluetooth_mower/bluetooth_mower/mowerconnection/commands/`.

I've removed the `get_parameter` and `set_parameter` functions for a generic `command` function as the commands themself now are describing their purpose. For example `nextStartTime --> GetNextStartTime` and `overrideDuration --> SetOverrideMow`.

I've removed the `"responseType": "no_response"` in protocol.json to keep it minimal and readable. 