### PR TITLE
Added StartTrigger to the "mower_override" method.

### DIFF
--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -45,7 +45,7 @@ class Mower(BLEClient):
         if command.validate_response(response) is False:
             # Just log if the response is invalid as this has been seen with user
             # logs from official apps. I.e. it is somewhat expected.
-            logger.debug("Response failed validation")
+            logger.warning("Response failed validation")
 
         response_dict = command.parse_response(response)
         if (
@@ -124,10 +124,14 @@ class Mower(BLEClient):
         # Set the duration of operation:
         await self.command("SetOverrideMow", duration=duration_hours * 3600)
 
+        # Request trigger to start, the response validation is expected to fail
+        await self.command("StartTrigger")
+
     async def mower_pause(self):
         await self.command("Pause")
 
     async def mower_resume(self):
+        # The response validation is expected to fail
         await self.command("StartTrigger")
 
     async def mower_park(self):


### PR DESCRIPTION
Based on [the android logs](https://github.com/alistair23/AutoMower-BLE/issues/53#issuecomment-2128781941) provided by @andyb2000 , I tested to included the `StartTrigger` command which results in that the mower starts the override mowing activity instantly. As added in my previous comment, this command however responds with a UNKNOWN_ERROR both in the android logs and when I test it myself.

For me, this PR now means that I've successfully tested the library against my AutoMower 305 and it correctly handles mower_override, mower_pause, mower_resume, mower_park all as expected.