### PR TITLE
Identify Gardena Sileno Life 750

### DIFF
--- a/automower_ble/models.py
+++ b/automower_ble/models.py
@@ -45,7 +45,7 @@ MowerModels = dict(
         ((16, 1), ModelInformation("Husqvarna", "Automower 550H")),
         ((17, 0), ModelInformation("Husqvarna", "Automower 520")),
         ((17, 1), ModelInformation("Husqvarna", "Automower 520H")),
-        ((18, 1), ModelInformation("Gardena", "SILENO Life Unknown (18,1)")),
+        ((18, 1), ModelInformation("Gardena", "SILENO Life 750")),
         ((18, 2), ModelInformation("Gardena", "SILENO Life Unknown (18,2)")),
         ((18, 3), ModelInformation("Gardena", "SILENO Life Unknown (18,3)")),
         ((18, 4), ModelInformation("Gardena", "Smart SILENO Life Unknown (18,4)")),


### PR DESCRIPTION
Great project! Just tested with my Gardena Sileno Life 750 and it connects fine. Will test more but for now at least the identification can be updated. 
More details from the sticker on my mower: 
Type: P0.2
Model: GARDENA SILENO life
15101-26
750m2
Product no. 9678453-06

<img width="724" alt="image" src="https://github.com/user-attachments/assets/7d632d0f-2c99-47e2-adb6-87b236a26c28">
