### PR TITLE
automower_ble/protocol: Only decode gatt chars if we read them

### DIFF
--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -497,14 +497,14 @@ class BLEClient:
                     )
 
                 if char.uuid == "00002a00-0000-1000-8000-00805f9b34fb":
-                    model = await client.read_gatt_char(char)
+                    model = (await client.read_gatt_char(char)).decode()
 
                 if char.uuid == "98bd0004-0b0e-421a-84e5-ddbf75dc6de4":
-                    device_type = await client.read_gatt_char(char)
+                    device_type = (await client.read_gatt_char(char)).decode()
 
         await client.disconnect()
 
-        return (manufacture, device_type.decode(), model.decode())
+        return (manufacture, device_type, model)
 
     async def disconnect(self):
         """


### PR DESCRIPTION
To avoid errors like

```
AttributeError: 'NoneType' object has no attribute 'decode'
```

we only decode the data when we read it instead of at the function return. This should avoid errors if we can't read it.

Resolves: https://github.com/home-assistant/core/issues/143827