### PR TITLE
Don't index into manufacturer_data to avoid out of range access

### DIFF
--- a/ble_scanner.py
+++ b/ble_scanner.py
@@ -12,6 +12,7 @@ from bleak import BleakScanner
 # Please see: https://bitbucket.org/bluetooth-SIG/public/src/main/assigned_numbers/company_identifiers/company_identifiers.yaml
 HUSQVARNA_COMPANY_IDENTIFIER = 0x0426
 
+
 async def main(args: argparse.Namespace):
     print(f"Scanning for {args.timeout} seconds, please wait...")
 
@@ -23,7 +24,11 @@ async def main(args: argparse.Namespace):
 
     husqvarna_device_found = False
     for d, a in devices.values():
-        if args.show_all or next(iter(a.manufacturer_data.keys()), None) == HUSQVARNA_COMPANY_IDENTIFIER:
+        if (
+            args.show_all
+            or next(iter(a.manufacturer_data.keys()), None)
+            == HUSQVARNA_COMPANY_IDENTIFIER
+        ):
             if not husqvarna_device_found and not args.show_all:
                 print("Husqvarna device(s) found!")
                 husqvarna_device_found = True

--- a/ble_scanner.py
+++ b/ble_scanner.py
@@ -8,6 +8,9 @@ import asyncio
 
 from bleak import BleakScanner
 
+# "Husqvarna AB" maps to "0x0426" for the manufacturer data
+# Please see: https://bitbucket.org/bluetooth-SIG/public/src/main/assigned_numbers/company_identifiers/company_identifiers.yaml
+HUSQVARNA_COMPANY_IDENTIFIER = 0x0426
 
 async def main(args: argparse.Namespace):
     print(f"Scanning for {args.timeout} seconds, please wait...")
@@ -20,14 +23,12 @@ async def main(args: argparse.Namespace):
 
     husqvarna_device_found = False
     for d, a in devices.values():
-        # "Husqvarna AB" maps to "0x0426" for the manufacturer data
-        # Please see: https://bitbucket.org/bluetooth-SIG/public/src/main/assigned_numbers/company_identifiers/company_identifiers.yaml
-        if list(a.manufacturer_data.keys())[0] == 0x0426 or args.show_all:
+        if args.show_all or next(iter(a.manufacturer_data.keys()), None) == HUSQVARNA_COMPANY_IDENTIFIER:
             if not husqvarna_device_found and not args.show_all:
                 print("Husqvarna device(s) found!")
                 husqvarna_device_found = True
 
-            print(f"\nAddress: {d.address}")
+            print(f"\n\tAddress: {d.address}")
             print(f"\tName: {d.name}")
             print(f"\tSignal Strength: {a.rssi} dBm (closer to 0 is stronger)")
             if args.show_all:


### PR DESCRIPTION
This fixes an index out of range issue for devices that do not have any `manufacturer_data`.

```

Traceback (most recent call last):
  File "/Users/christopher/Development/AutoMower-BLE/./ble_scanner.py", line 61, in <module>
    asyncio.run(main(args))
    ~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/usr/local/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/local/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 720, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/Users/christopher/Development/AutoMower-BLE/./ble_scanner.py", line 26, in main
    if list(a.manufacturer_data.keys())[0] == 0x0426 or args.show_all:
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```