### PR TITLE
Report ResponseResult NOT_ALLOWED on auth errors

### DIFF
--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -441,6 +441,11 @@ class BLEClient:
                             ",".join(char.properties),
                             e,
                         )
+                        if (
+                            char.uuid == "98bd0002-0b0e-421a-84e5-ddbf75dc6de4"
+                            or char.uuid == "98bd0003-0b0e-421a-84e5-ddbf75dc6de4"
+                        ):
+                            return ResponseResult.NOT_ALLOWED
 
                 else:
                     logger.debug(


### PR DESCRIPTION
If we can't probe the characteristics then report a NOT_ALLOWED error to help debug authentication issues.