### PR TITLE
Enable additional ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ ignore = [
   "G003",    # Logging statement uses +
   "G004",    # Logging statement uses f-string
   "PLE1205", # Too many arguments for logging format string
+  "PT009",   # Use a regular `assert` instead of unittest-style `assertEqual`
   "RET505",  # Unnecessary else after return
   "SIM103",  # Return the condition
   "SIM401",  # if-else-block-instead-of-dict-get

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,131 @@ required-version = ">=0.4.2"
 
 [tool.setuptools.package-data]
 automower_ble = ["*.json"]
+
+[tool.ruff.lint]
+select = [
+  "A001",   # Variable {name} is shadowing a Python builtin
+  "ASYNC",  # flake8-async
+  "B002",   # Python does not support the unary prefix increment
+  "B005",   # Using .strip() with multi-character strings is misleading
+  "B007",   # Loop control variable {name} not used within loop body
+  "B009",   # Do not call getattr with a constant attribute value. It is not any safer than normal property access.
+  "B014",   # Exception handler with duplicate exception
+  "B015",   # Pointless comparison. Did you mean to assign a value? Otherwise, prepend assert or remove it.
+  "B017",   # pytest.raises(BaseException) should be considered evil
+  "B018",   # Found useless attribute access. Either assign it to a variable or remove it.
+  "B023",   # Function definition does not bind loop variable {name}
+  "B024",   # `{name}` is an abstract base class, but it has no abstract methods or properties
+  "B026",   # Star-arg unpacking after a keyword argument is strongly discouraged
+  "B032",   # Possible unintentional type annotation (using :). Did you mean to assign (using =)?
+  "B035",   # Dictionary comprehension uses static key
+  "B904",   # Use raise from to specify exception cause
+  "B905",   # zip() without an explicit strict= parameter
+  "BLE",
+  "C",      # complexity
+  "COM818", # Trailing comma on bare tuple prohibited
+  "DTZ003", # Use datetime.now(tz=) instead of datetime.utcnow()
+  "DTZ004", # Use datetime.fromtimestamp(ts, tz=) instead of datetime.utcfromtimestamp(ts)
+  "E",      # pycodestyle
+  "F",      # pyflakes/autoflake
+  "F541",   # f-string without any placeholders
+  "FLY",    # flynt
+  "FURB",   # refurb
+  "G",      # flake8-logging-format
+  "INP",    # flake8-no-pep420
+  "ISC",    # flake8-implicit-str-concat
+  "ICN001", # import concentions; {name} should be imported as {asname}
+  "LOG",    # flake8-logging
+  "N804",   # First argument of a class method should be named cls
+  "N805",   # First argument of a method should be named self
+  "N815",   # Variable {name} in class scope should not be mixedCase
+  "PERF",   # Perflint
+  "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
+  "PL",     # pylint
+  "PT",     # flake8-pytest-style
+  "PTH",    # flake8-pathlib
+  "PYI",    # flake8-pyi
+  "RET",    # flake8-return
+  "RSE",    # flake8-raise
+  "RUF005", # Consider iterable unpacking instead of concatenation
+  "RUF006", # Store a reference to the return value of asyncio.create_task
+  "RUF007", # Prefer itertools.pairwise() over zip() when iterating over successive pairs
+  "RUF008", # Do not use mutable default values for dataclass attributes
+  "RUF010", # Use explicit conversion flag
+  "RUF013", # PEP 484 prohibits implicit Optional
+  "RUF016", # Slice in indexed access to type {value_type} uses type {index_type} instead of an integer
+  "RUF017", # Avoid quadratic list summation
+  "RUF018", # Avoid assignment expressions in assert statements
+  "RUF019", # Unnecessary key check before dictionary access
+  "RUF020", # {never_like} | T is equivalent to T
+  "RUF021", # Parenthesize a and b expressions when chaining and and or together, to make the precedence clear
+  "RUF022", # Sort __all__
+  "RUF023", # Sort __slots__
+  "RUF024", # Do not pass mutable objects as values to dict.fromkeys
+  "RUF026", # default_factory is a positional-only argument to defaultdict
+  "RUF030", # print() call in assert statement is likely unintentional
+  "RUF032", # Decimal() called with float literal argument
+  "RUF033", # __post_init__ method with argument defaults
+  "RUF034", # Useless if-else condition
+  "RUF100", # Unused `noqa` directive
+  "RUF101", # noqa directives that use redirected rule codes
+  "RUF200", # Failed to parse pyproject.toml: {message}
+  "S102",   # Use of exec detected
+  "S103",   # bad-file-permissions
+  "S108",   # hardcoded-temp-file
+  "S306",   # suspicious-mktemp-usage
+  "S307",   # suspicious-eval-usage
+  "S313",   # suspicious-xmlc-element-tree-usage
+  "S314",   # suspicious-xml-element-tree-usage
+  "S315",   # suspicious-xml-expat-reader-usage
+  "S316",   # suspicious-xml-expat-builder-usage
+  "S317",   # suspicious-xml-sax-usage
+  "S318",   # suspicious-xml-mini-dom-usage
+  "S319",   # suspicious-xml-pull-dom-usage
+  "S601",   # paramiko-call
+  "S602",   # subprocess-popen-with-shell-equals-true
+  "S604",   # call-with-shell-equals-true
+  "S608",   # hardcoded-sql-expression
+  "S609",   # unix-command-wildcard-injection
+  "SIM",    # flake8-simplify
+  "SLF",    # flake8-self
+  "SLOT",   # flake8-slots
+  "T100",   # Trace found: {name} used
+  "TC",     # flake8-type-checking
+  "TID",    # Tidy imports
+  "TRY",    # tryceratops
+  "UP",     # pyupgrade
+  "UP031",  # Use format specifiers instead of percent format
+  "UP032",  # Use f-string instead of `format` call
+  "W",      # pycodestyle
+]
+
+ignore = [
+  "C901",    # Function is too complex
+  "PLR0911", # Too many return statements ({returns} > {max_returns})
+  "PLR0912", # Too many branches ({branches} > {max_branches})
+  "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
+  "PLR0915", # Too many statements ({statements} > {max_statements})
+  "PLR1714", # Consider merging multiple comparison
+  "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
+  "TRY003",  # Avoid specifying long messages outside the exception class
+  "TRY400",  # Use `logging.exception` instead of `logging.error`
+
+  # Temporarily disabled rules
+  "A001",    # Variable is shadowing a builtin
+  "BLE001",  # Do not catch blind exception
+  "C406",    # Unnecessary list literal
+  "C408",    # Unnecessary dict call
+  "E501",    # Line too long
+  "G003",    # Logging statement uses +
+  "G004",    # Logging statement uses f-string
+  "PLE1205", # Too many arguments for logging format string
+  "RET505",  # Unnecessary else after return
+  "SIM103",  # Return the condition
+  "SIM401",  # if-else-block-instead-of-dict-get
+  "SLF001",  # Private member accessed
+  "UP004",   # Class inherits from object
+  "UP017",   # Use datetime.UTC alias
+  "UP031",   # Use format specifiers instead of percent format
+]


### PR DESCRIPTION
Enable additional ruff rules

Sub-rules which are currently violated are ignored, they should be enabled in separate PRs