### PR TITLE
Remove trailing null bytes from device type

### DIFF
--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -519,7 +519,9 @@ class BLEClient:
                     model = (await client.read_gatt_char(char)).decode()
 
                 if char.uuid == "98bd0004-0b0e-421a-84e5-ddbf75dc6de4":
-                    device_type = (await client.read_gatt_char(char)).decode()
+                    device_type = (
+                        (await client.read_gatt_char(char)).rstrip(b"\x00").decode()
+                    )
 
         await client.disconnect()
 


### PR DESCRIPTION
On the Automower 420, the device type handle appears to be 20 bytes long (MTU_SIZE ?) and padded with null bytes (0x00). This MR ensures that any potential trailing null bytes are removed before decoding.

```
2025-08-11 15:11:32.973 INFO (MainThread) [automower_ble.protocol] connecting to device...
2025-08-11 15:11:34.321 INFO (MainThread) [automower_ble.protocol] connected
2025-08-11 15:11:34.322 DEBUG (MainThread) [automower_ble.protocol] [Service] 00001800-0000-1000-8000-00805f9b34fb (Handle: 1): Generic Access Profile
2025-08-11 15:11:34.425 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 00002a00-0000-1000-8000-00805f9b34fb (Handle: 3): Device Name (read), Value: bytearray(b'Scarab\xc3\xa9e')
2025-08-11 15:11:34.627 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 00002a01-0000-1000-8000-00805f9b34fb (Handle: 5): Appearance (read), Value: bytearray(b'\x00\x00')
2025-08-11 15:11:34.731 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 00002a04-0000-1000-8000-00805f9b34fb (Handle: 7): Peripheral Preferred Connection Parameters (read), Value: bytearray(b'P\x00\xa0\x00\x00\x00\xe8\x03')
2025-08-11 15:11:34.732 DEBUG (MainThread) [automower_ble.protocol] [Service] 00001801-0000-1000-8000-00805f9b34fb (Handle: 8): Generic Attribute Profile
2025-08-11 15:11:34.732 DEBUG (MainThread) [automower_ble.protocol] [Service] 98bd0001-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 9): Husqvarna
2025-08-11 15:11:34.732 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 98bd0002-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 11): Unknown (write-without-response)
2025-08-11 15:11:34.834 ERROR (MainThread) [automower_ble.protocol]   [Characteristic] 98bd0003-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 14): Unknown (read,notify), Error: Bluetooth GATT Error address=D8:B6:73:40:05:F4 handle=14 error=15 description=Insufficient encryption
2025-08-11 15:11:34.934 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 98bd0004-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 18): Unknown (read), Value: bytearray(b'Automower\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
2025-08-11 15:11:35.056 DEBUG (MainThread) [custom_components.husqvarna_automower_ble] Found device: Husqvarna Automower�����������
```