### PR TITLE
Fix get_response() error handling

### DIFF
--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -293,8 +293,6 @@ class BLEClient:
 
         except TimeoutError:
             logger.error("Unable to get response from device: '%s'", self.address)
-            if self.is_connected():
-                await self.disconnect()
             return None
 
         return data


### PR DESCRIPTION
`_get_response()` should not disconnect the client on timeout. It is the responsibility of the caller functions to handle response issues:
- `_read_data()` checks whether any data was received.
- `_request_response()` retries up to 5 times to get a response. If none is received, this function disconnects the client.

Without this fix, the next loop iteration in _request_response() tries to request a response using a disconnected BleakClient. This may cause a Bleak deadlock because nothing happens afterwards.

```
2025-08-11 17:52:36.025 INFO (MainThread) [automower_ble.protocol] starting scan...
2025-08-11 17:52:36.025 INFO (MainThread) [automower_ble.protocol] connecting to device...
2025-08-11 17:52:40.605 INFO (MainThread) [automower_ble.protocol] connected
2025-08-11 17:52:40.605 INFO (MainThread) [automower_ble.protocol] pairing device...
2025-08-11 17:52:41.425 INFO (MainThread) [automower_ble.protocol] paired
2025-08-11 17:52:41.425 INFO (MainThread) [automower_ble.protocol] [Service] 00001800-0000-1000-8000-00805f9b34fb (Handle: 1): Generic Access Profile
2025-08-11 17:52:41.666 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 00002a00-0000-1000-8000-00805f9b34fb (Handle: 3): Device Name (read), Value: bytearray(b'Scarab\xc3\xa9e')
2025-08-11 17:52:41.833 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 00002a01-0000-1000-8000-00805f9b34fb (Handle: 5): Appearance (read), Value: bytearray(b'\x00\x00')
2025-08-11 17:52:42.164 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 00002a04-0000-1000-8000-00805f9b34fb (Handle: 7): Peripheral Preferred Connection Parameters (read), Value: bytearray(b'P\x00\xa0\x00\x00\x00\xe8\x03')
2025-08-11 17:52:42.164 INFO (MainThread) [automower_ble.protocol] [Service] 00001801-0000-1000-8000-00805f9b34fb (Handle: 8): Generic Attribute Profile
2025-08-11 17:52:42.165 INFO (MainThread) [automower_ble.protocol] [Service] 98bd0001-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 9): Husqvarna
2025-08-11 17:52:42.165 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 98bd0002-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 11): Unknown (write-without-response)
2025-08-11 17:52:42.345 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 98bd0003-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 14): Unknown (read,notify), Value: bytearray(b'\x03')
2025-08-11 17:52:42.857 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 98bd0004-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 18): Unknown (read), Value: bytearray(b'Automower\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
2025-08-11 17:52:47.883 INFO (MainThread) [automower_ble.protocol] Writing: b'02fd160000000000002e14f2c9e7dc000000004d61696e008d03'
2025-08-11 17:52:47.885 DEBUG (MainThread) [automower_ble.protocol] Finished writing
2025-08-11 17:52:57.887 ERROR (MainThread) [automower_ble.protocol] Unable to get response from device: 'D8:B6:73:40:05:F4'
2025-08-11 17:52:57.890 INFO (MainThread) [automower_ble.protocol] disconnecting...
2025-08-11 17:52:57.931 INFO (MainThread) [automower_ble.protocol] disconnected
2025-08-11 17:52:57.932 INFO (MainThread) [automower_ble.protocol] Writing: b'02fd160000000000002e14f2c9e7dc000000004d61696e008d03'
```

With fix : 

```
2025-08-11 17:45:03.434 INFO (MainThread) [automower_ble.protocol] starting scan...
2025-08-11 17:45:03.434 INFO (MainThread) [automower_ble.protocol] connecting to device...
2025-08-11 17:45:05.538 INFO (MainThread) [automower_ble.protocol] connected
2025-08-11 17:45:05.538 INFO (MainThread) [automower_ble.protocol] pairing device...
2025-08-11 17:45:05.944 INFO (MainThread) [automower_ble.protocol] paired
2025-08-11 17:45:05.945 INFO (MainThread) [automower_ble.protocol] [Service] 00001800-0000-1000-8000-00805f9b34fb (Handle: 1): Generic Access Profile
2025-08-11 17:45:06.046 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 00002a00-0000-1000-8000-00805f9b34fb (Handle: 3): Device Name (read), Value: bytearray(b'Scarab\xc3\xa9e')
2025-08-11 17:45:06.147 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 00002a01-0000-1000-8000-00805f9b34fb (Handle: 5): Appearance (read), Value: bytearray(b'\x00\x00')
2025-08-11 17:45:06.351 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 00002a04-0000-1000-8000-00805f9b34fb (Handle: 7): Peripheral Preferred Connection Parameters (read), Value: bytearray(b'P\x00\xa0\x00\x00\x00\xe8\x03')
2025-08-11 17:45:06.352 INFO (MainThread) [automower_ble.protocol] [Service] 00001801-0000-1000-8000-00805f9b34fb (Handle: 8): Generic Attribute Profile
2025-08-11 17:45:06.352 INFO (MainThread) [automower_ble.protocol] [Service] 98bd0001-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 9): Husqvarna
2025-08-11 17:45:06.353 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 98bd0002-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 11): Unknown (write-without-response)
2025-08-11 17:45:06.557 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 98bd0003-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 14): Unknown (read,notify), Value: bytearray(b'\x03')
2025-08-11 17:45:06.664 DEBUG (MainThread) [automower_ble.protocol]   [Characteristic] 98bd0004-0b0e-421a-84e5-ddbf75dc6de4 (Handle: 18): Unknown (read), Value: bytearray(b'Automower\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
2025-08-11 17:45:11.686 DEBUG (MainThread) [automower_ble.protocol] Writing: b'02fd160000000000002e146ea944a3000000004d61696e004f03'
2025-08-11 17:45:11.688 DEBUG (MainThread) [automower_ble.protocol] Finished writing
2025-08-11 17:45:21.689 ERROR (MainThread) [automower_ble.protocol] Unable to get response from device: 'D8:B6:73:40:05:F4'
2025-08-11 17:45:21.691 DEBUG (MainThread) [automower_ble.protocol] Writing: b'02fd160000000000002e146ea944a3000000004d61696e004f03'
2025-08-11 17:45:21.697 DEBUG (MainThread) [automower_ble.protocol] Finished writing
2025-08-11 17:45:31.699 ERROR (MainThread) [automower_ble.protocol] Unable to get response from device: 'D8:B6:73:40:05:F4'
2025-08-11 17:45:31.699 DEBUG (MainThread) [automower_ble.protocol] Writing: b'02fd160000000000002e146ea944a3000000004d61696e004f03'
2025-08-11 17:45:31.703 DEBUG (MainThread) [automower_ble.protocol] Finished writing
2025-08-11 17:45:41.705 ERROR (MainThread) [automower_ble.protocol] Unable to get response from device: 'D8:B6:73:40:05:F4'
2025-08-11 17:45:41.706 DEBUG (MainThread) [automower_ble.protocol] Writing: b'02fd160000000000002e146ea944a3000000004d61696e004f03'
2025-08-11 17:45:41.710 DEBUG (MainThread) [automower_ble.protocol] Finished writing
2025-08-11 17:45:51.711 ERROR (MainThread) [automower_ble.protocol] Unable to get response from device: 'D8:B6:73:40:05:F4'
2025-08-11 17:45:51.712 DEBUG (MainThread) [automower_ble.protocol] Writing: b'02fd160000000000002e146ea944a3000000004d61696e004f03'
2025-08-11 17:45:51.715 DEBUG (MainThread) [automower_ble.protocol] Finished writing
2025-08-11 17:46:01.717 ERROR (MainThread) [automower_ble.protocol] Unable to get response from device: 'D8:B6:73:40:05:F4'
2025-08-11 17:46:01.717 ERROR (MainThread) [automower_ble.protocol] Unable to communicate with device: 'D8:B6:73:40:05:F4'
2025-08-11 17:46:01.720 INFO (MainThread) [automower_ble.protocol] disconnecting...
2025-08-11 17:46:01.772 INFO (MainThread) [automower_ble.protocol] disconnected
```