### PR TITLE
Interpret UNKNOWN_ERROR from EnterOperatorPin as INVALID_PIN

### DIFF
--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -466,7 +466,13 @@ class BLEClient:
             response = await self._request_response(request)
             if response is None:
                 return ResponseResult.UNKNOWN_ERROR
-            return self.get_response_result(response)
+            result = self.get_response_result(response)
+            # If the result is UNKNOWN_ERROR, assume the pin was invalid
+            return (
+                ResponseResult.INVALID_PIN
+                if result == ResponseResult.UNKNOWN_ERROR
+                else result
+            )
 
         return ResponseResult.OK
 


### PR DESCRIPTION
Interpret UNKNOWN_ERROR from EnterOperatorPin as INVALID_PIN

Rationale:
My mower (Gardena Sileno smart max) replies with `ResponseResult.UNKNOWN_ERROR`, not `ResponseResult.INVALID_PIN` when sending `EnterOperatorPin` with wrong PIN as shown in this log:

```
2025-08-20 13:29:11.543 INFO (MainThread) [automower_ble.protocol] Writing: b'02fd1200fccba937019500af3812040002000709b403'
2025-08-20 13:29:11.544 DEBUG (MainThread) [automower_ble.protocol] Finished writing
2025-08-20 13:29:12.667 INFO (MainThread) [automower_ble.protocol] Received: b'02fd1100fccba93701d201af381204000100000003'
2025-08-20 13:29:12.668 DEBUG (MainThread) [automower_ble.protocol] Waiting for 21 bytes
2025-08-20 13:29:12.668 INFO (MainThread) [automower_ble.protocol] Final response: b'02fd1100fccba93701d201af381204000100000003'
2025-08-20 13:29:12.668 WARNING (MainThread) [automower_ble.protocol] Non zero response result: 1
2025-08-20 13:29:12.668 WARNING (MainThread) [automower_ble.protocol] Response failed validation
```