### PR TITLE
Add commands to fetch single statistics

### DIFF
--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -57,42 +57,6 @@
       "cuttingBladeUsageTime": "uint32"
     }
   },
-  "GetTotalRunningTime": {
-    "major": 4726,
-    "minor": 1,
-    "responseType": "uint32",
-    "description": "Total running time of the mower."
-  },
-  "GetTotalCuttingTime": {
-    "major": 4726,
-    "minor": 2,
-    "responseType": "uint32",
-    "description": "Total cutting time of the mower."
-  },
-  "GetTotalChargingTime": {
-    "major": 4726,
-    "minor": 3,
-    "responseType": "uint32",
-    "description": "Total charging time of the mower."
-  },
-  "GetTotalSearchingTime": {
-    "major": 4726,
-    "minor": 4,
-    "responseType": "uint32",
-    "description": "Total searching time of the mower."
-  },
-  "GetNumberOfCollisions": {
-    "major": 4726,
-    "minor": 5,
-    "responseType": "uint32",
-    "description": "Number of collisions detected by the mower."
-  },
-  "GetNumberOfChargingCycles": {
-    "major": 4726,
-    "minor": 6,
-    "responseType": "uint32",
-    "description": "Number of charging cycles completed by the mower."
-  },
   "EnterOperatorPin": {
     "major": 4664,
     "minor": 4,
@@ -245,5 +209,41 @@
     "minor": 5,
     "description": "Get the user defined mower name",
     "responseType": "ascii"
+  },
+  "GetTotalRunningTime": {
+    "major": 4726,
+    "minor": 1,
+    "responseType": "uint32",
+    "description": "Total running time of the mower."
+  },
+  "GetTotalCuttingTime": {
+    "major": 4726,
+    "minor": 2,
+    "responseType": "uint32",
+    "description": "Total cutting time of the mower."
+  },
+  "GetTotalChargingTime": {
+    "major": 4726,
+    "minor": 3,
+    "responseType": "uint32",
+    "description": "Total charging time of the mower."
+  },
+  "GetTotalSearchingTime": {
+    "major": 4726,
+    "minor": 4,
+    "responseType": "uint32",
+    "description": "Total searching time of the mower."
+  },
+  "GetNumberOfCollisions": {
+    "major": 4726,
+    "minor": 5,
+    "responseType": "uint32",
+    "description": "Number of collisions detected by the mower."
+  },
+  "GetNumberOfChargingCycles": {
+    "major": 4726,
+    "minor": 6,
+    "responseType": "uint32",
+    "description": "Number of charging cycles completed by the mower."
   }
 }


### PR DESCRIPTION
This makes it possible to fetch statistics on mowers that do not provide **cuttingBladeUsageTime**, as those generate an error when running the **GetAllStatistics** command.