### PR TITLE
Use bleak-retry-connector to handle connections

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install bleak
+          pip install bleak-retry-connector
           pip install mypy==1.17.0
       - name: Type check with mypy
         run: |

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install bleak
+          pip install bleak-retry-connector
           pip install pytest
       - name: Test with pytest
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
   "bleak",
+  "bleak_retry_connector",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Use bleak-retry-connector for automatic retry logic and better error handling.