### PR TITLE
Add Gardena mower protocol features

### DIFF
--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -302,7 +302,10 @@ class Mower(BLEClient):
         return result
 
     async def mower_park(self):
-        await self.command("SetOverrideParkUntilNextStart")
+        # Duration 0 matches the app's "park until further notice/permanently"
+        # option. "Park until next start" can resume immediately when a manual
+        # or smart schedule is still active.
+        await self.command("SetOverridePark", duration=0)
 
         # Request trigger to start, the response validation is expected to fail
         # [AT] Seems not needed for Gardena. It resumes the mower!

--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -27,11 +27,17 @@ from bleak import BleakScanner
 
 logger = logging.getLogger(__name__)
 
+MAX_SCHEDULE_TASKS = 15
+SECONDS_PER_MINUTE = 60
+MINUTES_PER_DAY = 24 * 60
+SPOT_CUT_DURATION_SECONDS = 30 * SECONDS_PER_MINUTE
+
 
 class Mower(BLEClient):
     def __init__(self, channel_id: int, address, pin=None):
         super().__init__(channel_id, address, pin)
         self.keep_alive_event = asyncio.Event()
+        self.task: asyncio.Task | None = None
 
     async def connect(self, device) -> ResponseResult:
         """
@@ -41,7 +47,9 @@ class Mower(BLEClient):
         """
         status = await super().connect(device)
         if status == ResponseResult.OK:
-            self.task = asyncio.create_task(self._keep_alive())
+            self.keep_alive_event.clear()
+            if self.task is None or self.task.done():
+                self.task = asyncio.create_task(self._keep_alive())
         return status
 
     async def disconnect(self):
@@ -50,7 +58,16 @@ class Mower(BLEClient):
         `connect()` before the Python script exits
         """
         self.keep_alive_event.set()
-        return await super().disconnect()
+        try:
+            return await super().disconnect()
+        finally:
+            if self.task is not None and self.task is not asyncio.current_task():
+                self.task.cancel()
+                try:
+                    await self.task
+                except asyncio.CancelledError:
+                    pass
+                self.task = None
 
     async def _keep_alive(self):
         """
@@ -88,6 +105,65 @@ class Mower(BLEClient):
         ):  # If there is only one key in the response, return the value
             return response_dict["response"]
         return response_dict
+
+    async def command_response(
+        self, command_name: str, warn_on_error: bool = True, **kwargs
+    ):
+        """
+        Send a command and return the mower response result with parsed data.
+
+        This is useful for command buttons where Home Assistant should surface a
+        clear command failure instead of only logging a low-level protocol warning.
+        """
+        command = Command(self.channel_id, (await self.get_protocol())[command_name])
+        request = command.generate_request(**kwargs)
+        response = await self._request_response(request)
+        if response is None:
+            return ResponseResult.UNKNOWN_ERROR, None
+
+        result = ResponseResult(response[16])
+        if result is not ResponseResult.OK:
+            if warn_on_error:
+                logger.warning("%s returned %s", command_name, result.name)
+            else:
+                logger.debug("%s returned %s", command_name, result.name)
+            return result, None
+
+        try:
+            response_dict = command.parse_response(response)
+        except ValueError as err:
+            logger.debug("%s returned unparsable payload: %s", command_name, err)
+            return result, None
+        if response_dict is not None and len(response_dict) == 1:
+            return result, response_dict["response"]
+        return result, response_dict
+
+    async def command_response_locked(
+        self, command_name: str, warn_on_error: bool = True, **kwargs
+    ):
+        """Send a command while the caller already holds the BLE command lock."""
+        command = Command(self.channel_id, (await self.get_protocol())[command_name])
+        request = command.generate_request(**kwargs)
+        response = await self._request_response_locked(request)
+        if response is None:
+            return ResponseResult.UNKNOWN_ERROR, None
+
+        result = ResponseResult(response[16])
+        if result is not ResponseResult.OK:
+            if warn_on_error:
+                logger.warning("%s returned %s", command_name, result.name)
+            else:
+                logger.debug("%s returned %s", command_name, result.name)
+            return result, None
+
+        try:
+            response_dict = command.parse_response(response)
+        except ValueError as err:
+            logger.debug("%s returned unparsable payload: %s", command_name, err)
+            return result, None
+        if response_dict is not None and len(response_dict) == 1:
+            return result, response_dict["response"]
+        return result, response_dict
 
     async def get_manufacturer(self) -> str | None:
         """Get the mower manufacturer"""
@@ -169,22 +245,81 @@ class Mower(BLEClient):
         # The response validation is expected to fail
         await self.command("StartTrigger")
 
+    async def mower_spot_cut(self) -> ResponseResult:
+        """
+        Start spot cutting.
+
+        The dedicated StartSpotCutting command is rejected with INVALID_ID on
+        some Gardena models. The official app first arms SpotCut, then starts
+        a manual mowing override.
+        """
+        async with self.lock:
+            result, _ = await self.command_response_locked(
+                "SetMode", mode=ModeOfOperation.AUTO
+            )
+            if result is not ResponseResult.OK:
+                return result
+
+            result, _ = await self.command_response_locked("PrepareSpotCutting")
+            if result is not ResponseResult.OK:
+                return result
+
+            result, _ = await self.command_response_locked(
+                "SetOverrideMow", duration=SPOT_CUT_DURATION_SECONDS
+            )
+            if result is not ResponseResult.OK:
+                return result
+
+            result, _ = await self.command_response_locked(
+                "StartTrigger", warn_on_error=False
+            )
+            if result is ResponseResult.OK:
+                return result
+
+            if result is ResponseResult.UNKNOWN_ERROR:
+                await asyncio.sleep(2)
+                _, state = await self.command_response_locked(
+                    "GetState", warn_on_error=False
+                )
+                _, activity = await self.command_response_locked(
+                    "GetActivity", warn_on_error=False
+                )
+                if (
+                    state == MowerState.IN_OPERATION
+                    and activity == MowerActivity.MOWING
+                ):
+                    logger.debug(
+                        "StartTrigger returned UNKNOWN_ERROR but mower is mowing"
+                    )
+                    return ResponseResult.OK
+
+            logger.warning("StartTrigger returned %s", result.name)
+            return result
+
+    async def mower_stop_spot_cut(self) -> ResponseResult:
+        """Stop SpotCut by pausing the mower, matching the app-observed flow."""
+        result, _ = await self.command_response("Pause")
+        return result
+
     async def mower_park(self):
         await self.command("SetOverrideParkUntilNextStart")
 
         # Request trigger to start, the response validation is expected to fail
-        await self.command("StartTrigger")
+        # [AT] Seems not needed for Gardena. It resumes the mower!
+        # await self.command("StartTrigger")
 
     async def get_task(self, taskid: int) -> TaskInformation | None:
         """
         Get information about a specific task
         """
-        task = await self.command("GetTask", taskId=taskid)
-        if task is None:
+        result, task = await self.command_response(
+            "GetTask", warn_on_error=False, taskId=taskid
+        )
+        if result is not ResponseResult.OK or task is None:
             return None
         return TaskInformation(
-            task["start"],
-            task["duration"],
+            task["start"] // SECONDS_PER_MINUTE,
+            (task["duration"] + SECONDS_PER_MINUTE - 1) // SECONDS_PER_MINUTE,
             task["useOnMonday"],
             task["useOnTuesday"],
             task["useOnWednesday"],
@@ -193,6 +328,99 @@ class Mower(BLEClient):
             task["useOnSaturday"],
             task["useOnSunday"],
         )
+
+    async def get_tasks(self) -> list[TaskInformation]:
+        """Get all weekly schedule tasks from the mower."""
+        task_count = await self.command("GetNumberOfTasks")
+        if task_count is None:
+            return []
+        logger.debug("Mower reported %s schedule tasks", task_count)
+
+        for first_task_id in (0, 1):
+            tasks: list[TaskInformation] = []
+            for task_id in range(first_task_id, first_task_id + task_count):
+                task = await self.get_task(task_id)
+                if task is None:
+                    logger.debug("Unable to read schedule task %s", task_id)
+                    break
+                tasks.append(task)
+            if len(tasks) == task_count:
+                logger.debug(
+                    "Read %s schedule tasks starting at task id %s",
+                    len(tasks),
+                    first_task_id,
+                )
+                return tasks
+
+        logger.debug("Unable to read mower schedule tasks")
+        return []
+
+    async def set_tasks(self, tasks: list[TaskInformation]) -> None:
+        """Replace the weekly schedule tasks on the mower."""
+        if len(tasks) > MAX_SCHEDULE_TASKS:
+            raise ValueError(
+                f"A maximum of {MAX_SCHEDULE_TASKS} schedule tasks is supported"
+            )
+
+        for task in tasks:
+            if (
+                task.start_time_in_minutes < 0
+                or task.start_time_in_minutes >= MINUTES_PER_DAY
+            ):
+                raise ValueError("Schedule start time must be within one day")
+            if (
+                task.duration_in_minutes <= 0
+                or task.duration_in_minutes > MINUTES_PER_DAY
+            ):
+                raise ValueError(
+                    "Schedule duration must be between 1 minute and 24 hours"
+                )
+
+        await self._expect_ok("StartTaskTransaction")
+        await self._expect_ok("DeleteAllTask")
+
+        for task in tasks:
+            logger.debug(
+                "Writing schedule task start=%s duration=%s days=%s",
+                task.start_time_in_minutes,
+                task.duration_in_minutes,
+                {
+                    "monday": bool(task.on_monday),
+                    "tuesday": bool(task.on_tuesday),
+                    "wednesday": bool(task.on_wednesday),
+                    "thursday": bool(task.on_thursday),
+                    "friday": bool(task.on_friday),
+                    "saturday": bool(task.on_saturday),
+                    "sunday": bool(task.on_sunday),
+                },
+            )
+            await self._expect_ok(
+                "AddTask",
+                start=int(task.start_time_in_minutes) * SECONDS_PER_MINUTE,
+                duration=int(task.duration_in_minutes) * SECONDS_PER_MINUTE,
+                useOnMonday=bool(task.on_monday),
+                useOnTuesday=bool(task.on_tuesday),
+                useOnWednesday=bool(task.on_wednesday),
+                useOnThursday=bool(task.on_thursday),
+                useOnFriday=bool(task.on_friday),
+                useOnSaturday=bool(task.on_saturday),
+                useOnSunday=bool(task.on_sunday),
+                unknown=0,
+            )
+
+        await self._expect_ok("CommitTaskTransaction")
+
+    async def clear_tasks(self) -> None:
+        """Remove all weekly schedule tasks from the mower."""
+        await self._expect_ok("StartTaskTransaction")
+        await self._expect_ok("DeleteAllTask")
+        await self._expect_ok("CommitTaskTransaction")
+
+    async def _expect_ok(self, command_name: str, **kwargs) -> None:
+        """Send a command and raise when the mower rejects it."""
+        result, _ = await self.command_response(command_name, **kwargs)
+        if result is not ResponseResult.OK:
+            raise RuntimeError(f"{command_name} returned {result.name}")
 
 
 async def main(mower: Mower):

--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -111,7 +111,7 @@ class Mower(BLEClient):
         if command.validate_command_response(response) is False:
             # Just log if the response is invalid as this has been seen with user
             # logs from official apps. I.e. it is somewhat expected.
-            logger.warning("Response failed validation")
+            logger.warning("Response failed validation for %s", command_name)
 
         response_dict = command.parse_response(response)
         if (
@@ -446,7 +446,9 @@ class Mower(BLEClient):
                 )
                 return ResponseResult.OK
 
-        logger.warning("StartTrigger returned %s while starting %s", result.name, context)
+        logger.warning(
+            "StartTrigger returned %s while starting %s", result.name, context
+        )
         return result
 
     async def mower_stop_spot_cut(self) -> ResponseResult:

--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -18,6 +18,7 @@ from automower_ble.protocol import (
     MowerState,
     MowerActivity,
     ModeOfOperation,
+    OverrideAction,
     ResponseResult,
     TaskInformation,
 )
@@ -39,6 +40,7 @@ class Mower(BLEClient):
         super().__init__(channel_id, address, pin)
         self.keep_alive_event = asyncio.Event()
         self.task: asyncio.Task | None = None
+        self._connect_lock = asyncio.Lock()
 
     async def connect(self, device) -> ResponseResult:
         """
@@ -46,12 +48,25 @@ class Mower(BLEClient):
 
         Returns a ResponseResult
         """
-        status = await super().connect(device)
-        if status == ResponseResult.OK:
-            self.keep_alive_event.clear()
-            if self.task is None or self.task.done():
-                self.task = asyncio.create_task(self._keep_alive())
-        return status
+        if self.is_connected():
+            self._ensure_keep_alive()
+            return ResponseResult.OK
+
+        async with self._connect_lock:
+            if self.is_connected():
+                self._ensure_keep_alive()
+                return ResponseResult.OK
+
+            status = await super().connect(device)
+            if status == ResponseResult.OK:
+                self._ensure_keep_alive()
+            return status
+
+    def _ensure_keep_alive(self) -> None:
+        """Start one keep-alive task for the active mower connection."""
+        self.keep_alive_event.clear()
+        if self.task is None or self.task.done():
+            self.task = asyncio.create_task(self._keep_alive())
 
     async def disconnect(self):
         """
@@ -207,12 +222,22 @@ class Mower(BLEClient):
             return None
         return MowerState(state)
 
-    async def mower_next_start_time(self) -> dt.datetime | None:
+    async def mower_next_start_time(
+        self, timezone: dt.tzinfo | None = None
+    ) -> dt.datetime | None:
         """Query the mower next start time"""
         next_start_time = await self.command("GetNextStartTime")
         if next_start_time is None or next_start_time == 0:
             return None
-        return dt.datetime.fromtimestamp(next_start_time, dt.UTC)
+        # The mower reports this value as seconds since epoch in local time, not
+        # UTC. Decode the timestamp as a UTC wall-clock value, then attach the
+        # desired local timezone so Home Assistant displays the actual schedule.
+        local_time = dt.datetime.fromtimestamp(next_start_time, dt.UTC).replace(
+            tzinfo=None
+        )
+        return local_time.replace(
+            tzinfo=timezone or dt.datetime.now().astimezone().tzinfo
+        )
 
     async def mower_activity(self) -> MowerActivity | None:
         """Query the mower activity"""
@@ -221,21 +246,106 @@ class Mower(BLEClient):
             return None
         return MowerActivity(activity)
 
-    async def mower_override(self, duration_hours: float = 3.0) -> None:
+    async def mower_mode(self) -> ModeOfOperation | None:
+        """Query the mower mode of operation."""
+        mode = await self.command("GetMode")
+        if mode is None:
+            return None
+        try:
+            return ModeOfOperation(mode)
+        except ValueError:
+            logger.debug("Unknown mower mode: %s", mode)
+            return None
+
+    async def mower_override_status(self) -> dict[str, int | OverrideAction] | None:
+        """Query the current mower override status."""
+        result, override = await self.command_response(
+            "GetOverride", warn_on_error=False
+        )
+        if result is not ResponseResult.OK or override is None:
+            return None
+
+        try:
+            action = OverrideAction(override["action"])
+        except ValueError:
+            logger.debug("Unknown mower override action: %s", override["action"])
+            action = OverrideAction.NONE
+
+        return {
+            "action": action,
+            "startTime": override["startTime"],
+            "duration": override["duration"],
+            "reserved": override["reserved"],
+        }
+
+    @staticmethod
+    def is_permanently_parked_state(
+        mode: ModeOfOperation | None, override: dict | None
+    ) -> bool:
+        """Return true if mode/override represent park until further notice."""
+        if mode is ModeOfOperation.HOME:
+            return True
+        return (
+            override is not None
+            and override.get("action") is OverrideAction.FORCEDPARK
+            and override.get("duration") == 0
+        )
+
+    async def mower_is_permanently_parked(self) -> bool:
+        """Return true if the mower is parked until further notice."""
+        mode = await self.mower_mode()
+        override = await self.mower_override_status()
+        return self.is_permanently_parked_state(mode, override)
+
+    async def mower_resume_schedule(self) -> ResponseResult:
+        """Return the mower to scheduled/automatic operation."""
+        result, _ = await self.command_response("ClearOverride", warn_on_error=False)
+        if result is not ResponseResult.OK:
+            logger.debug(
+                "ClearOverride returned %s while resuming schedule", result.name
+            )
+
+        result, _ = await self.command_response("SetMode", mode=ModeOfOperation.AUTO)
+        return result
+
+    async def mower_park_permanently(self) -> ResponseResult:
+        """Park the mower until further notice."""
+        result, _ = await self.command_response("SetMode", mode=ModeOfOperation.HOME)
+        return result
+
+    async def mower_override(self, duration_hours: float = 3.0) -> ResponseResult:
         """
         Force the mower to run for the specified duration in hours.
         """
         if duration_hours <= 0:
             raise ValueError("Duration must be greater than 0")
 
-        # Set mode of operation to auto:
-        await self.command("SetMode", mode=ModeOfOperation.AUTO)
+        async with self.lock:
+            result, _ = await self.command_response_locked(
+                "ClearOverride", warn_on_error=False
+            )
+            if result is not ResponseResult.OK:
+                logger.debug(
+                    "ClearOverride returned %s while starting manual mowing",
+                    result.name,
+                )
 
-        # Set the duration of operation:
-        await self.command("SetOverrideMow", duration=int(duration_hours * 3600))
+            result, _ = await self.command_response_locked(
+                "SetMode", mode=ModeOfOperation.AUTO
+            )
+            if result is not ResponseResult.OK:
+                return result
 
-        # Request trigger to start, the response validation is expected to fail
-        await self.command("StartTrigger")
+            result, _ = await self.command_response_locked(
+                "SetOverrideMow", duration=int(duration_hours * 3600)
+            )
+            if result is not ResponseResult.OK:
+                return result
+
+            return await self._start_trigger_locked(
+                "manual mowing",
+                (MowerActivity.GOING_OUT, MowerActivity.MOWING),
+            )
 
     async def mower_pause(self):
         await self.command("Pause")
@@ -253,6 +363,23 @@ class Mower(BLEClient):
         a manual mowing override.
         """
         async with self.lock:
+            result, _ = await self.command_response_locked("Pause", warn_on_error=False)
+            if result is ResponseResult.OK:
+                await asyncio.sleep(1)
+            elif result not in (
+                ResponseResult.UNKNOWN_ERROR,
+                ResponseResult.NOT_ALLOWED,
+            ):
+                logger.debug("Pause returned %s while starting SpotCut", result.name)
+
+            result, _ = await self.command_response_locked(
+                "ClearOverride", warn_on_error=False
+            )
+            if result is not ResponseResult.OK:
+                logger.debug(
+                    "ClearOverride returned %s while starting SpotCut", result.name
+                )
+
             result, _ = await self.command_response_locked(
                 "SetMode", mode=ModeOfOperation.AUTO
             )
@@ -272,43 +399,73 @@ class Mower(BLEClient):
             result, _ = await self.command_response_locked(
                 "StartTrigger", warn_on_error=False
             )
-            if result is ResponseResult.OK:
-                return result
-
-            if result is ResponseResult.UNKNOWN_ERROR:
-                await asyncio.sleep(2)
-                _, state = await self.command_response_locked(
-                    "GetState", warn_on_error=False
+            if result is not ResponseResult.OK:
+                return await self._start_trigger_result_locked(
+                    result,
+                    "SpotCut",
+                    (MowerActivity.MOWING,),
                 )
-                _, activity = await self.command_response_locked(
-                    "GetActivity", warn_on_error=False
-                )
-                if (
-                    state == MowerState.IN_OPERATION
-                    and activity == MowerActivity.MOWING
-                ):
-                    logger.debug(
-                        "StartTrigger returned UNKNOWN_ERROR but mower is mowing"
-                    )
-                    return ResponseResult.OK
 
-            logger.warning("StartTrigger returned %s", result.name)
             return result
+
+    async def _start_trigger_locked(
+        self, context: str, accepted_activities: tuple[MowerActivity, ...]
+    ) -> ResponseResult:
+        """Send StartTrigger and tolerate app-observed successful UNKNOWN_ERROR."""
+        result, _ = await self.command_response_locked(
+            "StartTrigger", warn_on_error=False
+        )
+        if result is ResponseResult.OK:
+            return result
+
+        return await self._start_trigger_result_locked(
+            result,
+            context,
+            accepted_activities,
+        )
+
+    async def _start_trigger_result_locked(
+        self,
+        result: ResponseResult,
+        context: str,
+        accepted_activities: tuple[MowerActivity, ...],
+    ) -> ResponseResult:
+        """Validate a StartTrigger result against the actual mower state."""
+        if result is ResponseResult.UNKNOWN_ERROR:
+            await asyncio.sleep(2)
+            _, state = await self.command_response_locked(
+                "GetState", warn_on_error=False
+            )
+            _, activity = await self.command_response_locked(
+                "GetActivity", warn_on_error=False
+            )
+            if state == MowerState.IN_OPERATION and activity in accepted_activities:
+                logger.debug(
+                    "StartTrigger returned UNKNOWN_ERROR but mower accepted %s",
+                    context,
+                )
+                return ResponseResult.OK
+
+        logger.warning("StartTrigger returned %s while starting %s", result.name, context)
+        return result
 
     async def mower_stop_spot_cut(self) -> ResponseResult:
         """Stop SpotCut by pausing the mower, matching the app-observed flow."""
         result, _ = await self.command_response("Pause")
         return result
 
-    async def mower_park(self):
-        # Duration 0 matches the app's "park until further notice/permanently"
-        # option. "Park until next start" can resume immediately when a manual
-        # or smart schedule is still active.
-        await self.command("SetOverridePark", duration=0)
+    async def mower_park(self) -> ResponseResult:
+        result, task_count = await self.command_response(
+            "GetNumberOfTasks", warn_on_error=False
+        )
+        if result is not ResponseResult.OK:
+            return result
 
-        # Request trigger to start, the response validation is expected to fail
-        # [AT] Seems not needed for Gardena. It resumes the mower!
-        # await self.command("StartTrigger")
+        if task_count:
+            result, _ = await self.command_response("SetOverrideParkUntilNextStart")
+            return result
+
+        return await self.mower_park_permanently()
 
     async def get_task(self, taskid: int) -> TaskInformation | None:
         """
@@ -378,6 +535,10 @@ class Mower(BLEClient):
                     "Schedule duration must be between 1 minute and 24 hours"
                 )
 
+        was_permanently_parked = False
+        if tasks:
+            was_permanently_parked = await self.mower_is_permanently_parked()
+
         await self._expect_ok("StartTaskTransaction")
         await self._expect_ok("DeleteAllTask")
 
@@ -411,6 +572,10 @@ class Mower(BLEClient):
             )
 
         await self._expect_ok("CommitTaskTransaction")
+        if tasks and was_permanently_parked:
+            result = await self.mower_resume_schedule()
+            if result is not ResponseResult.OK:
+                raise RuntimeError(f"SetMode returned {result.name}")
 
     async def clear_tasks(self) -> None:
         """Remove all weekly schedule tasks from the mower."""

--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -8,6 +8,7 @@ how the request and response classes can be used.
 
 import argparse
 import asyncio
+import contextlib
 import datetime as dt
 import logging
 
@@ -63,10 +64,8 @@ class Mower(BLEClient):
         finally:
             if self.task is not None and self.task is not asyncio.current_task():
                 self.task.cancel()
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await self.task
-                except asyncio.CancelledError:
-                    pass
                 self.task = None
 
     async def _keep_alive(self):

--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -77,11 +77,25 @@
         },
         "description": "Set SensorControl mowing time adjustment sensitivity."
     },
-    "GetFrostSensorEnabled": {
+    "GetFrostSensorEnabledLegacy": {
         "major": 4476,
         "minor": 6,
         "responseType": "bool",
+        "description": "Legacy frost sensor enabled state."
+    },
+    "GetFrostSensorEnabled": {
+        "major": 4692,
+        "minor": 6,
+        "responseType": "bool",
         "description": "Get frost sensor enabled state."
+    },
+    "SetFrostSensorEnabled": {
+        "major": 4692,
+        "minor": 5,
+        "requestType": {
+            "enabled": "bool"
+        },
+        "description": "Enable or disable the frost sensor."
     },
     "SetMode": {
         "major": 4586,
@@ -352,6 +366,11 @@
         "minor": 6,
         "responseType": "uint32",
         "description": "Number of charging cycles completed by the mower."
+    },
+    "ResetCuttingBladeUsageTime": {
+        "major": 4726,
+        "minor": 8,
+        "description": "Reset cutting blade usage time."
     },
     "GetNumberOfMessages": {
         "major": 4730,
@@ -658,6 +677,42 @@
         "responseType": "uint16",
         "description": "Supported mower accessory bitmask."
     },
+    "GenerateLoopSignal": {
+        "major": 4692,
+        "minor": 2,
+        "description": "Generate a new loop signal between mower and charging station."
+    },
+    "SetGarageEnabled": {
+        "major": 4692,
+        "minor": 3,
+        "requestType": {
+            "enabled": "bool"
+        },
+        "description": "Enable or disable avoid-garage behavior."
+    },
+    "GetGarageEnabled": {
+        "major": 4692,
+        "minor": 4,
+        "responseType": "bool",
+        "description": "Avoid-garage behavior state."
+    },
+    "SetAntiCollisionRadarEnabled": {
+        "major": 6050,
+        "minor": 3,
+        "requestType": {
+            "enabled": "bool"
+        },
+        "description": "Enable or disable Anti-collision Radar."
+    },
+    "GetAntiCollisionRadar": {
+        "major": 6050,
+        "minor": 4,
+        "responseType": {
+            "enabled": "bool",
+            "available": "bool"
+        },
+        "description": "Anti-collision Radar enabled and available state."
+    },
     "GetChargingStationLoopSignalGeneration": {
         "major": 5370,
         "minor": 1,
@@ -672,12 +727,12 @@
         },
         "description": "Enable or disable charging station loop signal generation or eco mode."
     },
-    "GenerateLoopSignal": {
+    "GenerateLoopSignalLegacy": {
         "major": 5356,
         "minor": 3,
         "requestType": {
             "signalType": "uint8"
         },
-        "description": "Generate a new loop signal between mower and charging station."
+        "description": "Legacy loop signal generation command."
     }
 }

--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -51,7 +51,7 @@
     },
     "GetSensorControlSensitivity": {
         "major": 4460,
-        "minor": 4,
+        "minor": 6,
         "responseType": "uint8",
         "description": "Get SensorControl mowing time adjustment sensitivity."
     },
@@ -65,7 +65,7 @@
     },
     "GetSensorControlEnabled": {
         "major": 4460,
-        "minor": 6,
+        "minor": 4,
         "responseType": "bool",
         "description": "Get SensorControl mowing time adjustment state."
     },
@@ -143,7 +143,8 @@
         "responseType": {
             "action": "uint8",
             "startTime": "tUnixTime",
-            "duration": "uint32"
+            "duration": "uint32",
+            "reserved": "remaining_uint"
         },
         "description": "Override status."
     },

--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -276,6 +276,12 @@
         "description": "Get the user defined mower name",
         "responseType": "ascii"
     },
+    "GetUserMowerName": {
+        "major": 4698,
+        "minor": 3,
+        "description": "Get the user defined mower name as UTF-16.",
+        "responseType": "utf16"
+    },
     "GetModel": {
         "major": 4698,
         "minor": 9,
@@ -290,6 +296,12 @@
         "minor": 10,
         "responseType": "uint32",
         "description": "Serial number of the mower."
+    },
+    "GetSoftwarePackageVersion": {
+        "major": 4698,
+        "minor": 22,
+        "responseType": "ascii",
+        "description": "Software package version string."
     },
     "GetAllStatistics": {
         "major": 4726,
@@ -374,6 +386,31 @@
             "guide3Signal": "sint16"
         },
         "description": "Realtime loop and guide signal quality."
+    },
+    "GetLoopSignals": {
+        "major": 4462,
+        "minor": 13,
+        "requestType": {
+            "signalType": "uint8"
+        },
+        "responseType": {
+            "a0Signal": "sint16",
+            "fSignal": "sint16",
+            "nSignal": "sint16",
+            "guide1Signal": "sint16",
+            "guide2Signal": "sint16",
+            "guide3Signal": "sint16"
+        },
+        "description": "Realtime loop and guide signal diagnostics used by the Gardena app."
+    },
+    "GetLoopSignalStrength": {
+        "major": 4462,
+        "minor": 14,
+        "requestType": {
+            "signalType": "uint8"
+        },
+        "responseType": "uint8",
+        "description": "Realtime loop signal strength percentage used by the Gardena app."
     },
 
     "GetComboardSensorData": {
@@ -613,5 +650,33 @@
         "minor": 5,
         "responseType": "uint16",
         "description": "Hardware revision."
+    },
+    "GetSupportedAccessories": {
+        "major": 4166,
+        "minor": 8,
+        "responseType": "uint16",
+        "description": "Supported mower accessory bitmask."
+    },
+    "GetChargingStationLoopSignalGeneration": {
+        "major": 5370,
+        "minor": 1,
+        "responseType": "bool",
+        "description": "Charging station loop signal generation or eco mode state."
+    },
+    "SetChargingStationLoopSignalGeneration": {
+        "major": 5370,
+        "minor": 2,
+        "requestType": {
+            "enabled": "bool"
+        },
+        "description": "Enable or disable charging station loop signal generation or eco mode."
+    },
+    "GenerateLoopSignal": {
+        "major": 5356,
+        "minor": 3,
+        "requestType": {
+            "signalType": "uint8"
+        },
+        "description": "Generate a new loop signal between mower and charging station."
     }
 }

--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -17,6 +17,24 @@
         "responseType": "uint32",
         "description": "Remaining charge time."
     },
+    "GetBatteryVoltage": {
+        "major": 4106,
+        "minor": 1,
+        "responseType": "uint16",
+        "description": "Battery voltage."
+    },
+    "GetBatteryCurrent": {
+        "major": 4106,
+        "minor": 8,
+        "responseType": "sint16",
+        "description": "Battery current."
+    },
+    "GetBatteryTemperature": {
+        "major": 4106,
+        "minor": 9,
+        "responseType": "sint16",
+        "description": "Battery temperature."
+    },
     "GetCuttingHeight": {
         "major": 4422,
         "minor": 2,
@@ -30,6 +48,40 @@
             "height": "uint8"
         },
         "description": "Cutting height, from 1 to 9 centimeters."
+    },
+    "GetSensorControlSensitivity": {
+        "major": 4460,
+        "minor": 4,
+        "responseType": "uint8",
+        "description": "Get SensorControl mowing time adjustment sensitivity."
+    },
+    "SetSensorControlEnabled": {
+        "major": 4460,
+        "minor": 5,
+        "requestType": {
+            "enabled": "bool"
+        },
+        "description": "Enable or disable SensorControl mowing time adjustment."
+    },
+    "GetSensorControlEnabled": {
+        "major": 4460,
+        "minor": 6,
+        "responseType": "bool",
+        "description": "Get SensorControl mowing time adjustment state."
+    },
+    "SetSensorControlSensitivity": {
+        "major": 4460,
+        "minor": 7,
+        "requestType": {
+            "sensitivity": "uint8"
+        },
+        "description": "Set SensorControl mowing time adjustment sensitivity."
+    },
+    "GetFrostSensorEnabled": {
+        "major": 4476,
+        "minor": 6,
+        "responseType": "bool",
+        "description": "Get frost sensor enabled state."
     },
     "SetMode": {
         "major": 4586,
@@ -176,7 +228,7 @@
             "useOnFriday": "bool",
             "useOnSaturday": "bool",
             "useOnSunday": "bool",
-            "unknown": "uint16"
+            "unknown": "remaining_uint"
         },
         "description": "Get a specified task"
     },
@@ -185,16 +237,15 @@
         "minor": 7,
         "requestType": {
             "start": "uint32",
-            "duration": "uint16",
-            "useOnSunday": "bool",
-            "unknown_1": "uint8",
+            "duration": "uint32",
             "useOnMonday": "bool",
             "useOnTuesday": "bool",
             "useOnWednesday": "bool",
             "useOnThursday": "bool",
             "useOnFriday": "bool",
             "useOnSaturday": "bool",
-            "unknown_2": "uint8"
+            "useOnSunday": "bool",
+            "unknown": "uint16"
         },
         "description": "Add a new task during a task transaction"
     },
@@ -306,5 +357,261 @@
             "code": "uint32",
             "severity": "uint8"
         }
+    },
+
+    "GetSignalQuality": {
+        "major": 20,
+        "minor": 21,
+        "responseType": {
+            "signalQuality": "uint8",
+            "a0Signal": "sint16",
+            "fSignal": "sint16",
+            "guide1Signal": "sint16",
+            "guide2Signal": "sint16",
+            "messageFromChargingStation": "uint16",
+            "inChargingStation": "uint8",
+            "nSignal": "sint16",
+            "guide3Signal": "sint16"
+        },
+        "description": "Realtime loop and guide signal quality."
+    },
+
+    "GetComboardSensorData": {
+        "major": 20,
+        "minor": 4,
+        "responseType": {
+            "collision": "uint8",
+            "lift": "uint8",
+            "pitch": "sint16",
+            "roll": "sint16",
+            "zAcceleration": "sint16",
+            "upsideDown": "uint8",
+            "mowerTemperature": "sint16"
+        },
+        "description": "Realtime mower sensor data."
+    },
+    "GetOrientationPitch": {
+        "major": 4958,
+        "minor": 0,
+        "responseType": "sint16",
+        "description": "Orientation pitch angle."
+    },
+    "GetOrientationRoll": {
+        "major": 4958,
+        "minor": 1,
+        "responseType": "sint16",
+        "description": "Orientation roll angle."
+    },
+
+    "GetDrivePastWire": {
+        "major": 4712,
+        "minor": 0,
+        "responseType": "uint16",
+        "description": "Get drive past wire distance."
+    },
+
+    "SetDrivePastWire": {
+        "major": 4712,
+        "minor": 1,
+        "requestType": {
+            "distance": "uint16"
+        },
+        "description": "Set drive past wire distance."
+    },
+
+    "GetAllDrivingSettings": {
+        "major": 4712,
+        "minor": 2,
+        "responseType": {
+            "drivePastWire": "uint16"
+        },
+        "description": "Get all driving settings."
+    },
+
+    "SubscribeDrivingSettingsEvents": {
+        "major": 4712,
+        "minor": 9,
+        "description": "Subscribe to driving settings events."
+    },
+
+    "GetReversingDistance": {
+        "major": 4716,
+        "minor": 0,
+        "responseType": "uint16",
+        "description": "Get distance from charging station to first starting point in millimeters."
+    },
+
+    "SetReversingDistance": {
+        "major": 4716,
+        "minor": 1,
+        "requestType": {
+            "distance": "uint16"
+        },
+        "description": "Set distance from charging station to first starting point in millimeters."
+    },
+
+    "GetAllLeaveChargingStationSettings": {
+        "major": 4716,
+        "minor": 15,
+        "responseType": {
+            "reversingDistance": "uint16"
+        },
+        "description": "Get all leave charging station settings."
+    },
+
+    "GetStartingPoint": {
+        "major": 4706,
+        "minor": 21,
+        "requestType": {
+            "startingPointId": "uint8"
+        },
+        "responseType": {
+            "enabled": "bool",
+            "proportion": "uint8",
+            "wire": "uint8",
+            "distance": "uint16",
+            "corridorCut": "bool"
+        },
+        "description": "Get manual starting point settings."
+    },
+
+    "SetStartingPointEnabled": {
+        "major": 4706,
+        "minor": 7,
+        "requestType": {
+            "startingPointId": "uint8",
+            "enabled": "bool"
+        },
+        "description": "Enable or disable a manual starting point."
+    },
+
+    "SetStartingPointWire": {
+        "major": 4706,
+        "minor": 9,
+        "requestType": {
+            "startingPointId": "uint8",
+            "wire": "uint8"
+        },
+        "description": "Set the wire followed to reach a manual starting point."
+    },
+
+    "SetStartingPointDistance": {
+        "major": 4706,
+        "minor": 11,
+        "requestType": {
+            "startingPointId": "uint8",
+            "distance": "uint16"
+        },
+        "description": "Set manual starting point distance from charging station in meters."
+    },
+
+    "SetStartingPointProportion": {
+        "major": 4706,
+        "minor": 13,
+        "requestType": {
+            "startingPointId": "uint8",
+            "proportion": "uint8"
+        },
+        "description": "Set manual starting point mowing share in percent."
+    },
+
+    "SetStartingPointCorridorCut": {
+        "major": 4706,
+        "minor": 27,
+        "requestType": {
+            "startingPointId": "uint8",
+            "corridorCut": "bool"
+        },
+        "description": "Enable or disable CorridorCut for a manual starting point."
+    },
+
+    "GetSpotCutting": {
+        "major": 4,
+        "minor": 13,
+        "responseType": "uint8",
+        "description": "Get spot cutting activation state."
+    },
+
+    "PrepareSpotCutting": {
+        "major": 4710,
+        "minor": 7,
+        "description": "Prepare SpotCut before starting a manual mowing override."
+    },
+
+    "GetSpotCuttingState": {
+        "major": 4710,
+        "minor": 9,
+        "responseType": "uint8",
+        "description": "Get prepared SpotCut state."
+    },
+
+    "StartSpotCutting": {
+        "major": 14,
+        "minor": 20,
+        "responseType": "uint16",
+        "description": "Start spot cutting."
+    },
+
+    "StopSpotCutting": {
+        "major": 14,
+        "minor": 24,
+        "responseType": "uint16",
+        "description": "Stop spot cutting."
+    },
+
+    "GetSwVersionStringBoot": {
+        "major": 4720,
+        "minor": 0,
+        "responseType": "ascii",
+        "description": "Boot software version string."
+    },
+
+    "GetSwVersionStringAppl": {
+        "major": 4720,
+        "minor": 1,
+        "responseType": "ascii",
+        "description": "Application software version string."
+    },
+
+    "GetSwVersionStringSub": {
+        "major": 4720,
+        "minor": 2,
+        "responseType": "ascii",
+        "description": "Sub software version string."
+    },
+
+    "GetProductionTime": {
+        "major": 4758,
+        "minor": 1,
+        "responseType": "tUnixTime",
+        "description": "Mower production time."
+    },
+
+    "GetNodeIprId": {
+        "major": 4758,
+        "minor": 2,
+        "responseType": "ascii",
+        "description": "Node IPR ID."
+    },
+
+    "GetHusqvarnaId": {
+        "major": 4758,
+        "minor": 3,
+        "responseType": "ascii",
+        "description": "Husqvarna ID."
+    },
+
+    "GetHwSerialNumber": {
+        "major": 4758,
+        "minor": 4,
+        "responseType": "ascii",
+        "description": "Hardware serial number."
+    },
+
+    "GetHardwareRevision": {
+        "major": 4758,
+        "minor": 5,
+        "responseType": "uint16",
+        "description": "Hardware revision."
     }
 }

--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -334,7 +334,7 @@ class BLEClient:
         return data
 
     async def _write_data(self, data):
-        logger.info("Writing: %s", str(binascii.hexlify(data)))
+        logger.debug("Writing: %s", str(binascii.hexlify(data)))
 
         chunk_size = self.MTU_SIZE - 3
         for chunk in (
@@ -389,7 +389,7 @@ class BLEClient:
                 logger.error("Expecting %d bytes, only have %d", length, len(data))
                 return None
 
-        logger.info("Final response: %s", str(binascii.hexlify(data)))
+        logger.debug("Final response: %s", str(binascii.hexlify(data)))
 
         return data
 
@@ -437,6 +437,10 @@ class BLEClient:
         if device is None:
             logger.warning("Could not find device with address '%s'", self.address)
             return ResponseResult.UNKNOWN_ERROR
+
+        self.write_char = None
+        self.read_char = None
+        self._notify_started = False
 
         logger.info("connecting to device...")
         self.client = await establish_connection(
@@ -501,7 +505,7 @@ class BLEClient:
         async def notification_handler(
             characteristic: BleakGATTCharacteristic, data: bytearray
         ):
-            logger.info("Received: %s", str(binascii.hexlify(data)))
+            logger.debug("Received: %s", str(binascii.hexlify(data)))
             await self.queue.put(data)
 
         if self.write_char is None or self.read_char is None:
@@ -552,6 +556,10 @@ class BLEClient:
         return bool(self.client and self.client.is_connected)
 
     async def probe_gatts(self, device):
+        self.write_char = None
+        self.read_char = None
+        self._notify_started = False
+
         logger.info("connecting to device...")
         client = await establish_connection(
             BleakClientWithServiceCache,
@@ -610,6 +618,10 @@ class BLEClient:
         logger.info("disconnecting...")
         await self.client.disconnect()
         logger.info("disconnected")
+        self.client = None
+        self.write_char = None
+        self.read_char = None
+        self._notify_started = False
 
         await self.queue.put(None)
 

--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -1,5 +1,5 @@
 import binascii
-from automower_ble.helpers import crc
+from .helpers import crc
 from enum import IntEnum
 import asyncio
 import logging
@@ -76,8 +76,8 @@ class ResponseResult(IntEnum):
 class TaskInformation:
     def __init__(
         self,
-        next_start_time,
-        duration_in_seconds,
+        start_time_in_minutes,
+        duration_in_minutes,
         on_monday,
         on_tuesday,
         on_wednesday,
@@ -86,8 +86,8 @@ class TaskInformation:
         on_saturday,
         on_sunday,
     ):
-        self.next_start_time = next_start_time
-        self.duration_in_seconds = duration_in_seconds
+        self.start_time_in_minutes = start_time_in_minutes
+        self.duration_in_minutes = duration_in_minutes
         self.on_monday = on_monday
         self.on_tuesday = on_tuesday
         self.on_wednesday = on_wednesday
@@ -165,6 +165,11 @@ class Command:
                 elif request_type == "uint8":
                     request_length += 1
                     request_data += kwargs[request_name].to_bytes(1, byteorder="little")
+                elif request_type == "bool":
+                    request_length += 1
+                    request_data += (1 if kwargs[request_name] else 0).to_bytes(
+                        1, byteorder="little"
+                    )
                 else:
                     raise ValueError("Unknown request type: " + request_type)
         self.request_data[16] = request_length
@@ -201,6 +206,14 @@ class Command:
                     data[dpos : dpos + 2], byteorder="little"
                 )
                 dpos += 2
+            elif dtype == "sint16":
+                response[name] = int.from_bytes(
+                    data[dpos : dpos + 2], byteorder="little", signed=True
+                )
+                dpos += 2
+            elif dtype == "remaining_uint":
+                response[name] = int.from_bytes(data[dpos:], byteorder="little")
+                dpos = len(data)
             elif (dtype == "uint8") or (dtype == "bool"):
                 response[name] = data[dpos]
                 dpos += 1
@@ -283,7 +296,9 @@ class BLEClient:
         if self.protocol is None:
 
             def read_protocol_file():
-                with files("automower_ble").joinpath("protocol.json").open("r") as f:
+                protocol_file = files(__package__).joinpath("protocol.json")
+                logger.debug("Loading protocol from %s", protocol_file)
+                with protocol_file.open("r") as f:
                     return json.load(f)
 
             self.protocol = await asyncio.get_running_loop().run_in_executor(
@@ -318,16 +333,29 @@ class BLEClient:
         if data is None:
             return None
 
-        if len(data) < 3:
-            # We got such a small amount of data, let's try again
-            if (chunk := await self._get_response()) is None:
-                return None
-            data = data + chunk
+        while data and data[0] != 0x02:
+            packet_start = data.find(b"\x02")
+            if packet_start >= 0:
+                logger.debug(
+                    "Discarding stale response prefix: %s",
+                    binascii.hexlify(data[:packet_start]),
+                )
+                data = data[packet_start:]
+                break
 
-            if len(data) < 3:
-                # Something is wrong
+            logger.debug(
+                "Discarding stale response fragment: %s", binascii.hexlify(data)
+            )
+            data = await self._get_response()
+            if data is None:
                 return None
 
+        while len(data) < 3:
+            # We got such a small amount of data, let's try again.
+            chunk = await self._get_response()
+            if chunk is None:
+                return None
+            data += chunk
         length = data[2] + 4
 
         logger.debug("Waiting for %d bytes", length)
@@ -337,9 +365,9 @@ class BLEClient:
                 data = data + await asyncio.wait_for(self.queue.get(), timeout=5)
             except TimeoutError:
                 logger.error(
-                    "Unable to get full response from device: '%s', currently have %s",
-                    str(binascii.hexlify(data)),
+                    "Unable to get full response from device '%s', currently have %s",
                     self.address,
+                    str(binascii.hexlify(data)),
                 )
                 logger.error("Expecting %d bytes, only have %d", length, len(data))
                 return None
@@ -350,27 +378,29 @@ class BLEClient:
 
     async def _request_response(self, request_data):
         async with self.lock:
-            try:
-                # If there are previous responses, flush them out
-                while not self.queue.empty():
-                    await self.queue.get()
+            return await self._request_response_locked(request_data)
 
-                await self._write_data(request_data)
+    async def _request_response_locked(self, request_data):
+        """Send a request while the caller already holds the BLE command lock."""
+        try:
+            # If there are previous responses, flush them out
+            while not self.queue.empty():
+                await self.queue.get()
 
-                response_data = await self._read_data()
-                if response_data is None:
-                    logger.error(
-                        "Unable to communicate with device: '%s'", self.address
-                    )
-                    if self.is_connected():
-                        await self.disconnect()
-                    return None
+            await self._write_data(request_data)
 
-            except asyncio.exceptions.CancelledError:
-                logger.debug("Received CancelledError")
+            response_data = await self._read_data()
+            if response_data is None:
+                logger.error("Unable to communicate with device: '%s'", self.address)
                 if self.is_connected():
                     await self.disconnect()
                 return None
+
+        except asyncio.exceptions.CancelledError:
+            logger.debug("Received CancelledError")
+            if self.is_connected():
+                await self.disconnect()
+            return None
 
         return response_data
 

--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -17,6 +17,12 @@ logger = logging.getLogger(__name__)
 
 GARDENA_WRITE_CHAR = "98bd0002-0b0e-421a-84e5-ddbf75dc6de4"
 GARDENA_READ_CHAR = "98bd0003-0b0e-421a-84e5-ddbf75dc6de4"
+GARDENA_PROTOCOL_DESCRIPTOR_CHAR = "98bd0004-0b0e-421a-84e5-ddbf75dc6de4"
+GATT_AUTH_ERROR_TEXT = (
+    "Insufficient authentication",
+    "Insufficient authorization",
+    "Insufficient encryption",
+)
 
 
 class ModeOfOperation(IntEnum):
@@ -75,6 +81,18 @@ class ResponseResult(IntEnum):
     DEVICE_BUSY = 8
     INVALID_PIN = 9
     MOWER_BLOCKED = 10
+
+
+def _response_result_label(value: int) -> str:
+    try:
+        result = ResponseResult(value)
+    except ValueError:
+        return f"UNKNOWN_RESULT({value})"
+    return f"{result.name}({value})"
+
+
+def _is_gatt_auth_error(err: Exception) -> bool:
+    return any(text in str(err) for text in GATT_AUTH_ERROR_TEXT)
 
 
 class TaskInformation:
@@ -287,7 +305,12 @@ class Command:
         if (
             response_data[16] != 0x00
         ):  # result: OK(0), UNKNOWN_ERROR(1), INVALID_VALUE(2), OUT_OF_RANGE(3), NOT_AVAILABLE(4), NOT_ALLOWED(5), INVALID_GROUP(6), INVALID_ID(7), DEVICE_BUSY(8), INVALID_PIN(9), MOWER_BLOCKED(10);
-            logger.warning("Non zero response result: %d", response_data[16])
+            logger.warning(
+                "Command %d/%d returned %s",
+                self.major,
+                self.minor,
+                _response_result_label(response_data[16]),
+            )
             return False
 
         return True
@@ -373,6 +396,7 @@ class BLEClient:
             if chunk is None:
                 return None
             data += chunk
+
         length = data[2] + 4
 
         logger.debug("Waiting for %d bytes", length)
@@ -432,6 +456,10 @@ class BLEClient:
 
         Returns a ResponseResult
         """
+        if self.is_connected():
+            logger.debug("Already connected")
+            return ResponseResult.OK
+
         logger.info("starting scan...")
 
         if device is None:
@@ -454,8 +482,8 @@ class BLEClient:
         try:
             await self.client.pair()
             logger.info("paired")
-        except Exception as err:
-            logger.debug("Pairing not completed, continuing anyway: %s", err)
+        except BleakError as err:
+            logger.info("Pairing failed, continuing with protocol handshake: %s", err)
             if not self.client.is_connected:
                 return ResponseResult.UNKNOWN_ERROR
 
@@ -497,6 +525,12 @@ class BLEClient:
                             ",".join(char.properties),
                             e,
                         )
+                        if (
+                            char.uuid == "98bd0002-0b0e-421a-84e5-ddbf75dc6de4"
+                            or char.uuid == "98bd0003-0b0e-421a-84e5-ddbf75dc6de4"
+                        ):
+                            return ResponseResult.NOT_ALLOWED
+
                 else:
                     logger.debug(
                         "  [Characteristic] %s (%s)", char, ",".join(char.properties)
@@ -517,11 +551,32 @@ class BLEClient:
         try:
             await self.client.start_notify(self.read_char, notification_handler)
             self._notify_started = True
-        except Exception as err:
-            logger.warning("Unable to subscribe to mower notifications: %s", err)
-            if self.is_connected():
-                await self.disconnect()
-            return ResponseResult.NOT_ALLOWED
+        except BleakError as err:
+            if _is_gatt_auth_error(err):
+                logger.info(
+                    "Notification subscription needs BLE authentication; "
+                    "retrying pairing once"
+                )
+                try:
+                    await self.client.pair()
+                    await asyncio.sleep(1.0)
+                    await self.client.start_notify(self.read_char, notification_handler)
+                    self._notify_started = True
+                except BleakError as retry_err:
+                    logger.warning(
+                        "Unable to subscribe to mower notifications after "
+                        "pairing retry: %s",
+                        retry_err,
+                    )
+                    if self.is_connected():
+                        await self.disconnect()
+                    return ResponseResult.NOT_ALLOWED
+            else:
+                logger.warning("Unable to subscribe to mower notifications: %s", err)
+                if self.is_connected():
+                    await self.disconnect()
+                return ResponseResult.NOT_ALLOWED
+
         await asyncio.sleep(5.0)
 
         request = self.generate_request_setup_channel_id()
@@ -556,11 +611,10 @@ class BLEClient:
         return bool(self.client and self.client.is_connected)
 
     async def probe_gatts(self, device):
-        self.write_char = None
-        self.read_char = None
-        self._notify_started = False
-
         logger.info("connecting to device...")
+        if device is None:
+            raise BleakError(f"Could not find device with address '{self.address}'")
+
         client = await establish_connection(
             BleakClientWithServiceCache,
             device,
@@ -573,39 +627,58 @@ class BLEClient:
         model = None
         device_type = None
 
-        for service in client.services:
-            logger.debug("[Service] %s", service)
+        try:
+            for service in client.services:
+                logger.debug("[Service] %s", service)
 
-            if service.uuid == "98bd0001-0b0e-421a-84e5-ddbf75dc6de4":
-                manufacture = service.description
+                if service.uuid == "98bd0001-0b0e-421a-84e5-ddbf75dc6de4":
+                    manufacture = service.description
 
-            for char in service.characteristics:
-                if "read" in char.properties:
-                    try:
-                        value = await client.read_gatt_char(char.uuid)
-                        logger.debug(
-                            "  [Characteristic] %s (%s), Value: %r",
-                            char,
-                            ",".join(char.properties),
-                            value,
-                        )
-                        if char.uuid == "00002a00-0000-1000-8000-00805f9b34fb":
-                            model = value.decode()
-                        if char.uuid == "98bd0004-0b0e-421a-84e5-ddbf75dc6de4":
-                            device_type = value.rstrip(b"\x00").decode()
-                    except Exception as e:
-                        logger.error(
-                            "  [Characteristic] %s (%s), Error: %s",
-                            char,
-                            ",".join(char.properties),
-                            e,
-                        )
-                else:
-                    logger.debug(
-                        "  [Characteristic] %s (%s)", char, ",".join(char.properties)
+                for char in service.characteristics:
+                    properties = ",".join(char.properties)
+                    should_read = char.uuid in (
+                        "00002a00-0000-1000-8000-00805f9b34fb",
+                        GARDENA_PROTOCOL_DESCRIPTOR_CHAR,
                     )
 
-        await client.disconnect()
+                    if char.uuid in (GARDENA_WRITE_CHAR, GARDENA_READ_CHAR):
+                        logger.debug("  [Characteristic] %s (%s)", char, properties)
+                        continue
+
+                    if "read" in char.properties and should_read:
+                        try:
+                            value = await client.read_gatt_char(char.uuid)
+                            logger.debug(
+                                "  [Characteristic] %s (%s), Value: %r",
+                                char,
+                                properties,
+                                value,
+                            )
+                        except Exception as e:
+                            logger.debug(
+                                "  [Characteristic] %s (%s), Error: %s",
+                                char,
+                                properties,
+                                e,
+                            )
+                            continue
+
+                        if char.uuid == "00002a00-0000-1000-8000-00805f9b34fb":
+                            model = value.decode()
+
+                        if char.uuid == GARDENA_PROTOCOL_DESCRIPTOR_CHAR:
+                            device_type = value.rstrip(b"\x00").decode()
+
+                    elif "read" in char.properties:
+                        logger.debug(
+                            "  [Characteristic] %s (%s), Value skipped during probe",
+                            char,
+                            properties,
+                        )
+                    else:
+                        logger.debug("  [Characteristic] %s (%s)", char, properties)
+        finally:
+            await client.disconnect()
 
         return (manufacture, device_type, model)
 
@@ -688,7 +761,10 @@ class BLEClient:
         if (
             response_data[16] != 0x00
         ):  # result: OK(0), UNKNOWN_ERROR(1), INVALID_VALUE(2), OUT_OF_RANGE(3), NOT_AVAILABLE(4), NOT_ALLOWED(5), INVALID_GROUP(6), INVALID_ID(7), DEVICE_BUSY(8), INVALID_PIN(9), MOWER_BLOCKED(10);
-            logger.warning("Non zero response result: %d", response_data[16])
+            logger.warning(
+                "Protocol response returned %s",
+                _response_result_label(response_data[16]),
+            )
             return False
 
         return True

--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import json
 from importlib.resources import files
+from bleak import BleakError
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak_retry_connector import establish_connection, BleakClientWithServiceCache
 from typing import TYPE_CHECKING
@@ -13,6 +14,9 @@ if TYPE_CHECKING:
     from bleak import BleakClient
 
 logger = logging.getLogger(__name__)
+
+GARDENA_WRITE_CHAR = "98bd0002-0b0e-421a-84e5-ddbf75dc6de4"
+GARDENA_READ_CHAR = "98bd0003-0b0e-421a-84e5-ddbf75dc6de4"
 
 
 class ModeOfOperation(IntEnum):
@@ -226,6 +230,16 @@ class Command:
                     "\x00"
                 )  # Remove trailing null bytes
                 dpos += len(data)
+            elif dtype == "utf16":
+                if len(self.response_data_type) != 1:
+                    raise ValueError(
+                        "UTF-16 response type can currently only be used when there is only one response type"
+                    )
+                try:
+                    response[name] = data.decode("utf-16-le").rstrip("\x00")
+                except UnicodeDecodeError as err:
+                    raise ValueError("Unable to decode UTF-16 response") from err
+                dpos += len(data)
             else:
                 raise ValueError("Unknown data type: " + dtype)
         if dpos != len(data):
@@ -291,6 +305,9 @@ class BLEClient:
 
         self.client: BleakClient | None = None
         self.protocol = None
+        self.write_char: BleakGATTCharacteristic | None = None
+        self.read_char: BleakGATTCharacteristic | None = None
+        self._notify_started = False
 
     async def get_protocol(self):
         if self.protocol is None:
@@ -311,7 +328,7 @@ class BLEClient:
             data = await asyncio.wait_for(self.queue.get(), timeout=10)
 
         except TimeoutError:
-            logger.error("Unable to get response from device: '%s'", self.address)
+            logger.warning("Unable to get response from device: '%s'", self.address)
             return None
 
         return data
@@ -391,7 +408,7 @@ class BLEClient:
 
             response_data = await self._read_data()
             if response_data is None:
-                logger.error("Unable to communicate with device: '%s'", self.address)
+                logger.warning("Unable to communicate with device: '%s'", self.address)
                 if self.is_connected():
                     await self.disconnect()
                 return None
@@ -401,6 +418,11 @@ class BLEClient:
             if self.is_connected():
                 await self.disconnect()
             return None
+        except BleakError as err:
+            logger.warning("BLE communication failed: %s", err)
+            if self.is_connected():
+                await self.disconnect()
+            raise
 
         return response_data
 
@@ -413,7 +435,7 @@ class BLEClient:
         logger.info("starting scan...")
 
         if device is None:
-            logger.error("could not find device with address '%s'", self.address)
+            logger.warning("Could not find device with address '%s'", self.address)
             return ResponseResult.UNKNOWN_ERROR
 
         logger.info("connecting to device...")
@@ -430,6 +452,8 @@ class BLEClient:
             logger.info("paired")
         except Exception as err:
             logger.debug("Pairing not completed, continuing anyway: %s", err)
+            if not self.client.is_connected:
+                return ResponseResult.UNKNOWN_ERROR
 
         # This is not safe, _mtu_size is not defined in BaseBleakClient but may
         # be defined in subclasses.
@@ -439,10 +463,21 @@ class BLEClient:
             logger.info("[Service] %s", service)
 
             for char in service.characteristics:
-                if (
-                    "read" in char.properties
-                    and char.uuid != "98bd0003-0b0e-421a-84e5-ddbf75dc6de4"
-                ):
+                if char.uuid == GARDENA_WRITE_CHAR:
+                    self.write_char = char
+
+                if char.uuid == GARDENA_READ_CHAR:
+                    self.read_char = char
+
+                if char.uuid in (GARDENA_WRITE_CHAR, GARDENA_READ_CHAR):
+                    logger.debug(
+                        "  [Characteristic] %s (%s)",
+                        char,
+                        ",".join(char.properties),
+                    )
+                    continue
+
+                if "read" in char.properties:
                     try:
                         value = await self.client.read_gatt_char(char.uuid)
                         logger.debug(
@@ -452,7 +487,7 @@ class BLEClient:
                             value,
                         )
                     except Exception as e:
-                        logger.error(
+                        logger.debug(
                             "  [Characteristic] %s (%s), Error: %s",
                             char,
                             ",".join(char.properties),
@@ -462,11 +497,6 @@ class BLEClient:
                     logger.debug(
                         "  [Characteristic] %s (%s)", char, ",".join(char.properties)
                     )
-                if char.uuid == "98bd0002-0b0e-421a-84e5-ddbf75dc6de4":
-                    self.write_char = char
-
-                if char.uuid == "98bd0003-0b0e-421a-84e5-ddbf75dc6de4":
-                    self.read_char = char
 
         async def notification_handler(
             characteristic: BleakGATTCharacteristic, data: bytearray
@@ -474,12 +504,20 @@ class BLEClient:
             logger.info("Received: %s", str(binascii.hexlify(data)))
             await self.queue.put(data)
 
+        if self.write_char is None or self.read_char is None:
+            logger.error("Gardena protocol characteristics not found")
+            if self.is_connected():
+                await self.disconnect()
+            return ResponseResult.UNKNOWN_ERROR
+
         try:
             await self.client.start_notify(self.read_char, notification_handler)
-        except Exception:
-            await self.client.disconnect()
-            raise
-
+            self._notify_started = True
+        except Exception as err:
+            logger.warning("Unable to subscribe to mower notifications: %s", err)
+            if self.is_connected():
+                await self.disconnect()
+            return ResponseResult.NOT_ALLOWED
         await asyncio.sleep(5.0)
 
         request = self.generate_request_setup_channel_id()


### PR DESCRIPTION
This ports the generic Automower/Gardena BLE protocol work from the Home Assistant Gardena BLE integration back into the Python library.

Included:
- safer command response helpers that expose mower response results
- serialized locked command flow for multi-step commands
- keep-alive task cleanup on disconnect
- schedule transaction helpers for reading, replacing, and clearing weekly tasks
- Gardena-compatible SpotCut flow: prepare SpotCut, start timed override, then trigger start
- additional protocol definitions for battery diagnostics, SensorControl/frost sensor, drive-past-wire, starting points, reversing distance, SpotCut, realtime sensor data, signal quality, firmware/hardware identity, and production info
- parser support for signed 16-bit values and variable trailing integer fields, so GetTask works with both existing upstream fixtures and Gardena responses

Notes:
- The new commands were tested from the Home Assistant integration against a Gardena Sileno mower and cross-checked with Gardena app BLE/HCI observations where available.
- Some commands are model-dependent and may return NOT_AVAILABLE, INVALID_ID, or NOT_ALLOWED on mowers that do not expose that feature.

Validation:
- python -m unittest discover
- python -m compileall automower_ble tests
- git diff --check