### PR TITLE
Fix parse_response crash on empty response

### DIFF
--- a/automower_ble/protocol.py
+++ b/automower_ble/protocol.py
@@ -186,6 +186,10 @@ class Command:
     def parse_response(self, response_data: bytearray) -> dict[str, int | str] | None:
         response_length = response_data[17]
         data = response_data[19 : 19 + response_length]
+        if response_length == 0:
+            # A response length of 0 indicates that no data is available (e.g. GetMessage when there are no errors)
+            # This is a valid "no data available" response, not an error.
+            return None
         response: dict[str, int | str] = {}
         dpos = 0  # data position
         for name, dtype in self.response_data_type.items():

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -106,6 +106,13 @@ class TestRequestMethods(unittest.TestCase):
             1,
         )
 
+    def test_decode_empty_response(self):
+        command = Command(1197489078, self.protocol["GetMessage"])
+        response = command.parse_response(
+            bytearray.fromhex("02fd1100b63b604701db01af0a101500000000bc03")
+        )
+        self.assertIsNone(response)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Problem
When the mower returns a response with `response_length == 0` (for example, calling `GetMessage` when there are no logged errors), the library still attempts to parse fields according to the schema. 

For commands whose schemas contain `uint8` or `bool` fields, the parsing logic accesses the data array using direct indexing (`data[dpos]`). On an empty bytearray, this immediately raises an `IndexError: bytearray index out of range`, causing the library to crash.

### Solution
Directly after slicing `data` from the response packet, check if `response_length == 0`. If so, return `None` immediately, representing a valid "no data available" response.

### Verification
A unit test `test_decode_empty_response` was added to `tests/test_response.py` to verify that parsing a response packet with a data length of `0` returns `None` instead of raising an `IndexError`.
