### PR TITLE
Fix GetOverride response schema length mismatch

### DIFF
--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -91,7 +91,8 @@
         "responseType": {
             "action": "uint8",
             "startTime": "tUnixTime",
-            "duration": "uint32"
+            "duration": "uint32",
+            "unknown": "uint32"
         },
         "description": "Override status."
     },

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -106,6 +106,16 @@ class TestRequestMethods(unittest.TestCase):
             1,
         )
 
+    def test_decode_get_override_response(self):
+        command = Command(1197489078, self.protocol["GetOverride"])
+        decoded = command.parse_response(
+            bytearray.fromhex("02fd2000b63b604701db01af0a101500000d000140cd6764201c000000000000bc03")
+        )
+        self.assertEqual(decoded["action"], 1)
+        self.assertEqual(decoded["startTime"], 1684524352)
+        self.assertEqual(decoded["duration"], 7200)
+        self.assertEqual(decoded["unknown"], 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Problem
The current schema for the `GetOverride` responseType specifies:
- `action`: `uint8` (1 byte)
- `startTime`: `tUnixTime` (4 bytes)
- `duration`: `uint32` (4 bytes)

This expects a total payload size of 9 bytes. However, Husqvarna/Gardena mowers consistently return 13 bytes for this command. This leads to a decoding failure with the exception:
`ValueError: Data length mismatch. Read 9 bytes of 13`

### Solution
Manual decoding shows that the first 9 bytes contain correct values (action, startTime, and duration are decoded perfectly), leaving a trailing 4-byte chunk. This PR adds an `unknown: uint32` field to the `GetOverride` responseType schema to match the 13 bytes returned by mowers.

### Verification
A unit test `test_decode_get_override_response` was added to `tests/test_response.py` to verify that a 13-byte response for `GetOverride` decodes correctly.
