### PR TITLE
Fix GetTask response schema length mismatch

### DIFF
--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -176,7 +176,7 @@
             "useOnFriday": "bool",
             "useOnSaturday": "bool",
             "useOnSunday": "bool",
-            "unknown": "uint16"
+            "unknown": "uint32"
         },
         "description": "Get a specified task"
     },

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -77,7 +77,7 @@ class TestRequestMethods(unittest.TestCase):
         response = Command(1197489078, self.protocol["GetTask"])
         decoded = response.parse_response(
             bytearray.fromhex(
-                "02fd240025be246a010701af5212050000130000e1000038310000010001010001013003"
+                "02fd260025be246a010701af5212050000130000e100003831000001000101000101000000003003"
             )
         )
 
@@ -96,6 +96,7 @@ class TestRequestMethods(unittest.TestCase):
         self.assertEqual(decoded["useOnFriday"], 0)
         self.assertEqual(decoded["useOnSaturday"], 1)
         self.assertEqual(decoded["useOnSunday"], 1)
+        self.assertEqual(decoded["unknown"], 0)
 
     def test_decode_get_number_of_tasks_response(self):
         response = Command(0x13A51453, self.protocol["GetNumberOfTasks"])


### PR DESCRIPTION
### Problem
The current `GetTask` responseType schema has an expected size of 17 bytes (start: 4, duration: 4, 7 bools: 7, unknown: 2). However, mowers send 19 bytes of data for this command. Under normal operation, this triggers a decoding failure:
`ValueError: Data length mismatch. Read 17 bytes of 19`

*(Note: The existing unit test previously did not catch this because the mock hex string used was truncated to 17 bytes, matching the length mismatch but silently parsing it due to array slicing).*

### Solution
This PR changes the `unknown` field at the end of the `GetTask` responseType schema from `uint16` (2 bytes) to `uint32` (4 bytes). This brings the expected size to 19 bytes, matching the actual data structure returned by the mowers.

### Verification
- Updated `test_decode_get_task_response` in `tests/test_response.py` with a complete, non-truncated 19-byte hex payload.
- Added assertions to check that the trailing `unknown` field decodes to `0` and that the overall test suite passes successfully.
