### PR TITLE
models: Add Gardena Smart SILENO sense 600+650m2 (47, 2+5)

### DIFF
--- a/automower_ble/models.py
+++ b/automower_ble/models.py
@@ -110,4 +110,6 @@ MowerModels = {
     (39, 5): ModelInformation("Husqvarna", "Automower 410XE Nera"),
     (40, 1): ModelInformation("Husqvarna", "Automower 450X EPOS"),
     (40, 2): ModelInformation("Husqvarna", "Automower 450XH EPOS"),
+    (47, 2): ModelInformation("Gardena", "Smart SILENO sense 600m2"),
+    (47, 5): ModelInformation("Gardena", "Smart SILENO sense 650m2"),
 }


### PR DESCRIPTION
Confirmed by connecting to a physical unit; GetModel reported
deviceType=47, deviceVariant=2/5.