### PR TITLE
protocol: fix swapped eco mode / frost sensor command mapping

### DIFF
--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -83,6 +83,14 @@
         "responseType": "bool",
         "description": "Legacy frost sensor enabled state."
     },
+    "SetFrostSensorEnabledLegacy": {
+        "major": 4476,
+        "minor": 5,
+        "requestType": {
+            "enabled": "bool"
+        },
+        "description": "Enable or disable the legacy frost sensor."
+    },
     "GetFrostSensorEnabled": {
         "major": 4692,
         "minor": 6,

--- a/automower_ble/protocol.json
+++ b/automower_ble/protocol.json
@@ -91,19 +91,19 @@
         },
         "description": "Enable or disable the legacy frost sensor."
     },
-    "GetFrostSensorEnabled": {
+    "GetEcoModeEnabled": {
         "major": 4692,
         "minor": 6,
         "responseType": "bool",
-        "description": "Get frost sensor enabled state."
+        "description": "Get eco mode enabled state."
     },
-    "SetFrostSensorEnabled": {
+    "SetEcoModeEnabled": {
         "major": 4692,
         "minor": 5,
         "requestType": {
             "enabled": "bool"
         },
-        "description": "Enable or disable the frost sensor."
+        "description": "Enable or disable eco mode."
     },
     "SetMode": {
         "major": 4586,
@@ -721,19 +721,19 @@
         },
         "description": "Anti-collision Radar enabled and available state."
     },
-    "GetChargingStationLoopSignalGeneration": {
+    "GetFrostSensorEnabled": {
         "major": 5370,
         "minor": 1,
         "responseType": "bool",
-        "description": "Charging station loop signal generation or eco mode state."
+        "description": "Get frost sensor enabled state."
     },
-    "SetChargingStationLoopSignalGeneration": {
+    "SetFrostSensorEnabled": {
         "major": 5370,
         "minor": 2,
         "requestType": {
             "enabled": "bool"
         },
-        "description": "Enable or disable charging station loop signal generation or eco mode."
+        "description": "Enable or disable frost sensor."
     },
     "GenerateLoopSignalLegacy": {
         "major": 5356,

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -172,6 +172,14 @@ class TestRequestMethods(unittest.TestCase):
             b"02fd10005314a513016900af3212020000004103",
         )
 
+    def test_generate_request_set_frost_sensor_enabled_legacy(self):
+        command = Command(0x13A51453, parameter=self.protocol["SetFrostSensorEnabledLegacy"])
+
+        self.assertEqual(
+            binascii.hexlify(command.generate_request(enabled=True)),
+            b"02fd11005314a513015400af7c1105000100015d03",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Eco mode and frost sensor commands were mapped to each other's major/minor codes.
I swapped them back.

Verified on a GARDENA SILENO Minimo 250: toggling the frost sensor in the app
flips 5370/1, and 4692/6 is unaffected.

